### PR TITLE
fix: remove all em-dashes from blog posts

### DIFF
--- a/data/blog/37000-lines-of-slop.mdx
+++ b/data/blog/37000-lines-of-slop.mdx
@@ -25,11 +25,11 @@ A developer going by Gregorian audited Tan's blog after observing the productivi
 | Images | One PNG at 2MB, another at 1.99MB, zero modern image handling |
 | Editor | 520KB rich text editor speculatively shipped from backend to frontend |
 | Accessibility | 47 images with zero alt tags |
-| Rendering | Page content rendered twice — once mobile, once desktop |
+| Rendering | Page content rendered twice - once mobile, once desktop |
 
 The site loads. Scores 80 on Lighthouse. But "it works" is a dangerously low bar.
 
-Users on constrained connections, screen readers, older devices — they bear the real cost. As Tolinski puts it: "The web should not be treated as a dumping ground for unreviewed AI output simply because the result is technically functional."
+Users on constrained connections, screen readers, older devices - they bear the real cost. As Tolinski puts it: "The web should not be treated as a dumping ground for unreviewed AI output simply because the result is technically functional."
 
 ## Line Count Is a Terrible Metric
 
@@ -50,7 +50,7 @@ The code compiles. The tests pass. But hidden in those 37,000 lines:
 - Components rendered twice for responsive design
 - Rich text editors shipped speculatively
 
-Without review, these issues accumulate. The codebase becomes digital landfill — functional on the surface, broken underneath.
+Without review, these issues accumulate. The codebase becomes digital landfill - functional on the surface, broken underneath.
 
 ## Slowing Down
 
@@ -65,7 +65,7 @@ Practical guidance from Zechner:
 
 ## Tooling for Hygiene
 
-Tolinski has been exploring [Fallow](https://docs.fallow.tools/) — a static analysis tool for TypeScript and JavaScript codebases that surfaces:
+Tolinski has been exploring [Fallow](https://docs.fallow.tools/) - a static analysis tool for TypeScript and JavaScript codebases that surfaces:
 
 - Dead code
 - Duplicate lines

--- a/data/blog/ai-cli-battles.mdx
+++ b/data/blog/ai-cli-battles.mdx
@@ -11,11 +11,11 @@ draft: false
 
 The familiar hum of terminal sessions has taken on a new character lately. Where once we typed precise commands with surgical accuracy, developers are now conversing with their command line in plain English. What sounds revolutionary is actually the maturation of an idea that's been brewing since the early days of GPT-3.5[^1].
 
-Cast your mind back to the early days of 2023—light years ago in AI time. While everyone was marvelling at ChatGPT's conversational abilities, a handful of developers were asking a more ambitious question: what if we could delegate entire tasks to AI agents through the command line? [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT)[^2] emerged as the proof of concept, a scrappy tool that demonstrated the tantalising possibility of autonomous AI agents executing complex development workflows.
+Cast your mind back to the early days of 2023-light years ago in AI time. While everyone was marvelling at ChatGPT's conversational abilities, a handful of developers were asking a more ambitious question: what if we could delegate entire tasks to AI agents through the command line? [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT)[^2] emerged as the proof of concept, a scrappy tool that demonstrated the tantalising possibility of autonomous AI agents executing complex development workflows.
 
 The concept was brilliant in its simplicity: give an AI agent a goal, let it break down the task, execute commands, and iterate until completion. But like many pioneering technologies, AutoGPT was more proof-of-concept than production-ready tool. The foundation models weren't quite there yet, the tooling was rough around the edges, and the developer experience left much to be desired.
 
-Now, as the industry reaches critical mass, major vendors are presenting their refined versions of this same core concept. The question isn't whether AI-powered CLI tools will transform development workflows—it's which approach will define the next decade of software engineering.
+Now, as the industry reaches critical mass, major vendors are presenting their refined versions of this same core concept. The question isn't whether AI-powered CLI tools will transform development workflows-it's which approach will define the next decade of software engineering.
 
 ## The Testing Ground
 
@@ -31,13 +31,13 @@ The Laravel project became my primary testing ground - getting dev containers co
 
 The tool excels in several key areas:
 
-- **Codebase Intelligence**: Claude Code maps and explains entire codebases in a few seconds, using agentic search to understand project structure and dependencies without manual context selection. This "soft-cache" approach—essentially generating markdown documentation that explains your codebase—has become a defining pattern across AI CLI tools.
+- **Codebase Intelligence**: Claude Code maps and explains entire codebases in a few seconds, using agentic search to understand project structure and dependencies without manual context selection. This "soft-cache" approach-essentially generating markdown documentation that explains your codebase-has become a defining pattern across AI CLI tools.
 
 - **IDE Integration**: Rather than forcing developers to abandon their preferred environments, Claude Code offers extensions for VS Code, JetBrains, and Neovim. These extensions bridge the gap between terminal-based AI assistance and the rich context available through IDE APIs.
 
 - **Model Flexibility**: Support for Anthropic's full model suite, plus integration with Amazon Bedrock and Google Cloud Vertex AI, makes it enterprise-ready without vendor lock-in concerns.
 
-- **Thinking Modes**: Claude Code includes specific phrases that trigger extended thinking modes—"think" provides 4,000 tokens of thinking budget, while "ultrathink" allocates up to 31,999 tokens for complex reasoning[^4].
+- **Thinking Modes**: Claude Code includes specific phrases that trigger extended thinking modes-"think" provides 4,000 tokens of thinking budget, while "ultrathink" allocates up to 31,999 tokens for complex reasoning[^4].
 
 The downside? Cost and accessibility. API costs for a medium-sized PR typically range from $10-15[^5], making it a significant investment for frequent use.
 
@@ -53,11 +53,11 @@ Key differentiators include:
 
 - **Sandbox Execution**: Codex runs model-generated commands in a sandbox, allowing developers to review and approve changes before execution.
 
-Early comparisons suggest performance differences. One developer noted that "Claude Code did great and wrote pretty decent docs, while Codex didn't do well—it hallucinated a bunch of stuff that wasn't in the code and completely misrepresented the architecture"[^7].
+Early comparisons suggest performance differences. One developer noted that "Claude Code did great and wrote pretty decent docs, while Codex didn't do well-it hallucinated a bunch of stuff that wasn't in the code and completely misrepresented the architecture"[^7].
 
 ### Amazon Q Developer CLI
 
-Amazon's entry into this space reflects their cloud-first, enterprise-focused philosophy. The tool integrates deeply with AWS services but suffers from what I'd call "enterprise bloat"—requiring a desktop application for configuration and complex OAuth flows through IAM Identity Centre.
+Amazon's entry into this space reflects their cloud-first, enterprise-focused philosophy. The tool integrates deeply with AWS services but suffers from what I'd call "enterprise bloat"-requiring a desktop application for configuration and complex OAuth flows through IAM Identity Centre.
 
 > [!WARNING]
 > The concerning aspect is the proprietary model approach, I'm going to safely assume they're using Claude Sonnet 3.7 or 4. Without transparency into the underlying foundation models, developers face context management uncertainties.
@@ -76,7 +76,7 @@ The process is surprisingly straightforward:
 3. It generates a comprehensive markdown document explaining the codebase
 4. This documentation becomes the foundation for all subsequent interactions
 
-What's particularly clever is that this "soft-cache" can be portable between tools. You can use Claude Code to generate initial codebase documentation, then leverage that same understanding with OpenAI's Codex CLI or other tools. The pattern isn't proprietary—it's a natural evolution of how AI agents need to contextualise large codebases.
+What's particularly clever is that this "soft-cache" can be portable between tools. You can use Claude Code to generate initial codebase documentation, then leverage that same understanding with OpenAI's Codex CLI or other tools. The pattern isn't proprietary-it's a natural evolution of how AI agents need to contextualise large codebases.
 
 ## The IDE Integrations
 
@@ -98,7 +98,7 @@ Say I want to query technical documentation on the internet, I can simply add th
 
 The marketing materials paint an impressive picture, but real-world usage reveals important nuances. One developer spent a week with Claude Code on Clojure projects, investing $134.79 and 12 hours, ultimately concluding that "[Cursor](https://cursor.sh/) is a much better workflow for me" and that "AI without oversight is still not there to deliver maintainable apps"[^9].
 
-This highlights a crucial reality: these tools excel at the "first 90%" of development tasks but struggle with the "second 90%"—the refinement, debugging, and maintenance that transforms prototypes into production-ready applications.
+This highlights a crucial reality: these tools excel at the "first 90%" of development tasks but struggle with the "second 90%"-the refinement, debugging, and maintenance that transforms prototypes into production-ready applications.
 
 Tools hallucinate predictably when pushed beyond their boundaries. AWS Q Developer provided the clearest example when I requested it read external documentation for project configuration. Without MCP web request capabilities, it fabricated responses based on existing files rather than admitting limitation.
 
@@ -125,7 +125,7 @@ Companies like [Cursor](https://cursor.sh/), [Cognition](https://www.cognition-l
 
 ## Looking Forward: Beyond the Hype Cycle
 
-As someone who's watched developer tools evolve for over a decade, I see striking parallels to the early days of containerisation. [Docker](https://www.docker.com/)[^12] seemed magical initially—a universal solution to deployment complexity. But the real value emerged through the ecosystem that developed around it: orchestration platforms, service meshes, and cloud-native architectures.
+As someone who's watched developer tools evolve for over a decade, I see striking parallels to the early days of containerisation. [Docker](https://www.docker.com/)[^12] seemed magical initially-a universal solution to deployment complexity. But the real value emerged through the ecosystem that developed around it: orchestration platforms, service meshes, and cloud-native architectures.
 
 AI CLI tools are following a similar trajectory. The initial wow factor of natural language programming is giving way to more nuanced understanding of where these tools excel and where human expertise remains irreplaceable.
 
@@ -137,7 +137,7 @@ The most successful teams will likely adopt a hybrid approach:
 
 ## The Paradox of Choice
 
-Developers are now spoiled for choice when it comes to AI-powered development tools. The question isn't whether to adopt these technologies—it's which combination of tools provides the best fit for your specific context.
+Developers are now spoiled for choice when it comes to AI-powered development tools. The question isn't whether to adopt these technologies-it's which combination of tools provides the best fit for your specific context.
 
 Consider your development environment:
 - **For rapid prototyping**: Claude Code's comprehensive codebase understanding shines
@@ -145,7 +145,7 @@ Consider your development environment:
 - **For enterprise environments**: Amazon Q Developer provides AWS integration at the cost of transparency
 - **For IDE-centric workflows**: Cursor, Windsurf, or GitHub Copilot might be more natural fits
 
-The key insight is that this isn't a zero-sum game. The underlying patterns—codebase contextualisation, natural language interfaces, and agentic task delegation—are becoming table stakes across the industry.
+The key insight is that this isn't a zero-sum game. The underlying patterns-codebase contextualisation, natural language interfaces, and agentic task delegation-are becoming table stakes across the industry.
 
 ## Bottom Line
 

--- a/data/blog/ai-is-degrading-software-engineering.mdx
+++ b/data/blog/ai-is-degrading-software-engineering.mdx
@@ -2,7 +2,7 @@
 title: AI Is Degrading Software Engineering, Not Replacing It
 date: "2025-05-30 11:45:17 +1000"
 summary: |
-  The real AI transformation isn't mass unemployment. It's job degradation — breaking complex skilled work into simpler, faster tasks performed at increased speed. After mapping how this pattern is playing out at major tech companies, the warning signs are clear. Engineers aren't being replaced. They're being turned into assembly-line workers.
+  The real AI transformation isn't mass unemployment. It's job degradation - breaking complex skilled work into simpler, faster tasks performed at increased speed. After mapping how this pattern is playing out at major tech companies, the warning signs are clear. Engineers aren't being replaced. They're being turned into assembly-line workers.
 tags:
   - AI
   - Workplace Transformation
@@ -18,7 +18,7 @@ AI isn't eliminating developers. It's degrading the work. Breaking complex skill
 
 ## The Pattern From Industrial History
 
-When technology transformed manufacturing, the response wasn't mass unemployment. It was job degradation — complex skilled work broken into simpler, repetitive tasks performed at increased speed.
+When technology transformed manufacturing, the response wasn't mass unemployment. It was job degradation - complex skilled work broken into simpler, repetitive tasks performed at increased speed.
 
 Software engineering is following the same trajectory. The transformation isn't about job elimination. It's about job intensification.
 
@@ -32,7 +32,7 @@ The most significant change is engineers becoming "bystanders in their own jobs.
 
 Modern AI code generation tools can produce large program sections independently. This shifts the developer's role from active creation to passive review. From writing code to reading code. From building to verifying.
 
-As one programmer noted: "It's more fun to write code than to read code." When AI generates the bulk of the code, engineers spend most of their time reviewing and debugging rather than creating — a shift many find professionally unsatisfying.
+As one programmer noted: "It's more fun to write code than to read code." When AI generates the bulk of the code, engineers spend most of their time reviewing and debugging rather than creating - a shift many find professionally unsatisfying.
 
 | Traditional Development | AI-Assisted Development |
 |-------------------------|------------------------|
@@ -72,23 +72,23 @@ The vital 20% delivering 80% of value centres on work pace acceleration rather t
 
 The shift threatens traditional advancement paths.
 
-When AI handles testing and debugging — traditionally educational for junior developers — career progression becomes unclear. How do you learn to debug when the AI does it for you? How do you build intuition for system design when you're reviewing AI-generated code instead of writing it?
+When AI handles testing and debugging - traditionally educational for junior developers - career progression becomes unclear. How do you learn to debug when the AI does it for you? How do you build intuition for system design when you're reviewing AI-generated code instead of writing it?
 
-The risk is a talent pipeline gap. Junior developers lose the entry-level work that builds judgement. Senior developers find their review and validation skills stretched beyond capacity. The middle layer — where experience compounds into expertise — erodes.
+The risk is a talent pipeline gap. Junior developers lose the entry-level work that builds judgement. Senior developers find their review and validation skills stretched beyond capacity. The middle layer - where experience compounds into expertise - erodes.
 
 ## The Jevons Paradox for Code
 
 [William Stanley Jevons observed in 1865](https://en.wikipedia.org/wiki/Jevons_paradox) that as coal became more efficient to use, total coal consumption increased rather than decreased. The efficiency unlocked demand previously suppressed by cost.
 
-Software follows the same pattern. AI makes code generation dramatically cheaper. The result is more software being built, not less. More features, more products, more systems — each requiring maintenance, integration, and operational support.
+Software follows the same pattern. AI makes code generation dramatically cheaper. The result is more software being built, not less. More features, more products, more systems - each requiring maintenance, integration, and operational support.
 
 The demand for software engineers may actually increase in the short term. But the nature of the work degrades. More code. Less craft. Faster pace. Lower satisfaction.
 
 ## What This Means for Engineers
 
-**For experienced developers:** AI tools can eliminate tedious tasks like legacy software upgrades. The opportunity is using the time saved for more interesting work — architecture, system design, mentoring — rather than absorbing the productivity gain as increased output pressure.
+**For experienced developers:** AI tools can eliminate tedious tasks like legacy software upgrades. The opportunity is using the time saved for more interesting work - architecture, system design, mentoring - rather than absorbing the productivity gain as increased output pressure.
 
-**For career development:** The traditional path of learning through debugging and testing is narrowing. New paths will emerge, but they're not clear yet. Proactive skill development in areas AI handles poorly — architecture, integration, human judgement — becomes essential.
+**For career development:** The traditional path of learning through debugging and testing is narrowing. New paths will emerge, but they're not clear yet. Proactive skill development in areas AI handles poorly - architecture, integration, human judgement - becomes essential.
 
 **For organisations:** The challenge is balancing productivity gains with employee satisfaction and long-term innovation capacity. Without intervention, the trajectory toward intensified, monitored work will likely continue.
 

--- a/data/blog/ai-product-engineering-lego-blocks.mdx
+++ b/data/blog/ai-product-engineering-lego-blocks.mdx
@@ -14,9 +14,9 @@ Microsoft, Google, and Meta launch competing products monthly now. Not yearly. M
 
 The question isn't "can we build this?" anymore. It's "what do we build and why will it win?"
 
-That question got harder. Moats that lasted 6-12 months now survive 2-3 weeks. The answer is treating AI like Lego blocks — your advantage comes from how you assemble them with your unique stuff, not from the blocks themselves.
+That question got harder. Moats that lasted 6-12 months now survive 2-3 weeks. The answer is treating AI like Lego blocks - your advantage comes from how you assemble them with your unique stuff, not from the blocks themselves.
 
-I learned this lesson the hard way. The temptation to build custom models is real — fine-tuning on your corpus, custom preprocessing, optimised inference. It feels like a moat. But foundation models improve on a different cadence than product features. What's impressive today is baseline next quarter. The competitive advantage becomes a maintenance burden that costs more to run than the API alternatives.
+I learned this lesson the hard way. The temptation to build custom models is real - fine-tuning on your corpus, custom preprocessing, optimised inference. It feels like a moat. But foundation models improve on a different cadence than product features. What's impressive today is baseline next quarter. The competitive advantage becomes a maintenance burden that costs more to run than the API alternatives.
 
 The mistake isn't technical. It's strategic. Confusing "can we build this?" with "should we build this?" The moat isn't in the model. It was never going to be in the model.
 
@@ -96,15 +96,15 @@ Reinvention wastes cycles on solved problems. Copy-paste creates undifferentiate
 
 The reinvention trap usually looks like this: a team spends months building a custom model, proud of the accuracy numbers, the custom feature engineering, the hyperparameter tuning. Then someone runs the same data through a commercial API and matches or exceeds the results with zero training, zero maintenance, zero infrastructure.
 
-The demoralisation is real. But the mistake happened earlier — nobody asked "what's the marginal value of building this ourselves?" They'd assumed custom meant better. Sometimes it does. Usually it doesn't. The question isn't whether you can build it. It's whether building it creates value that buying it doesn't.
+The demoralisation is real. But the mistake happened earlier - nobody asked "what's the marginal value of building this ourselves?" They'd assumed custom meant better. Sometimes it does. Usually it doesn't. The question isn't whether you can build it. It's whether building it creates value that buying it doesn't.
 
 ### Platform Primitives in Practice
 
-When building an AI platform, we faced the reinvention question directly. Do we build a custom gateway, or buy one? Do we write our own model routing, or use an existing solution? The temptation to build was strong — we understood the problem deeply, and off-the-shelf solutions never fit perfectly.
+When building an AI platform, we faced the reinvention question directly. Do we build a custom gateway, or buy one? Do we write our own model routing, or use an existing solution? The temptation to build was strong - we understood the problem deeply, and off-the-shelf solutions never fit perfectly.
 
-We chose a hybrid: buy the gateway, build the SDK. The gateway handled model routing, failover, cost tracking — commodity capabilities where buying beat building. The SDK abstracted sessions, memory, tracing, and agent patterns — our unique layer that absorbed vendor pivots without rewriting applications.
+We chose a hybrid: buy the gateway, build the SDK. The gateway handled model routing, failover, cost tracking - commodity capabilities where buying beat building. The SDK abstracted sessions, memory, tracing, and agent patterns - our unique layer that absorbed vendor pivots without rewriting applications.
 
-This proved valuable when we later switched gateway vendors. The applications on top didn't change. The SDK absorbed the migration. The primitive — a consistent interface for AI interactions — outlasted the implementation.
+This proved valuable when we later switched gateway vendors. The applications on top didn't change. The SDK absorbed the migration. The primitive - a consistent interface for AI interactions - outlasted the implementation.
 
 The lesson: build where your unique context matters. Buy where the problem is already solved. The boundary moves as the market matures.
 
@@ -112,9 +112,9 @@ The lesson: build where your unique context matters. Buy where the problem is al
 
 Copy-paste competition is everywhere in AI right now. Same GPT-4 backend. Same "rewrite this paragraph" feature. Same Chrome extension. Same pricing. The only differentiation is landing page colour and founder Twitter following.
 
-The ones that survive don't win on AI. They win on workflow integration — the specific CMS their users can't live without, the approval chain that maps to how the team actually works, the data format that removes a manual export step. The AI is identical. The moat is the workflow.
+The ones that survive don't win on AI. They win on workflow integration - the specific CMS their users can't live without, the approval chain that maps to how the team actually works, the data format that removes a manual export step. The AI is identical. The moat is the workflow.
 
-Copy-paste competition is a race to the bottom on price. The winner is whoever has the most runway, not whoever has the best product. Avoid it by finding the seam that everyone else missed — the workflow your users spend 80% of their time in, the integration that removes friction they didn't know they had.
+Copy-paste competition is a race to the bottom on price. The winner is whoever has the most runway, not whoever has the best product. Avoid it by finding the seam that everyone else missed - the workflow your users spend 80% of their time in, the integration that removes friction they didn't know they had.
 
 ## Moat Timeline
 

--- a/data/blog/anthropic-study-ai-skill-formation.mdx
+++ b/data/blog/anthropic-study-ai-skill-formation.mdx
@@ -25,11 +25,11 @@ The finding is more specific than the headlines. It tells us something about how
 | Biggest weakness | Debugging | Less severe | The safety concern that matters |
 | Task context | New library, short window | Same | Not how real devs work |
 
-The AI group finished about two minutes faster — not statistically significant. But the quiz gap was nearly two letter grades.
+The AI group finished about two minutes faster - not statistically significant. But the quiz gap was nearly two letter grades.
 
 **The biggest drop was debugging ability.** That's the part that should worry us. Human oversight still matters, and debugging is where humans catch what AI misses.
 
-The debugging gap shows up in real work too. You describe what you want, review the output, ship it. The code works. Tests pass. Three weeks later something breaks in production — an edge case the agent hadn't considered — and you find yourself staring at error traces without a complete mental model. The agent built it, but you didn't build the understanding of how it works.
+The debugging gap shows up in real work too. You describe what you want, review the output, ship it. The code works. Tests pass. Three weeks later something breaks in production - an edge case the agent hadn't considered - and you find yourself staring at error traces without a complete mental model. The agent built it, but you didn't build the understanding of how it works.
 
 The response isn't to avoid agents. It's to change how you use them. Ask for explanations before implementation. Make them walk through control flow. If they use a pattern you don't recognise, stop and ask why. The conversation takes longer. The output is better. And when things break, you can actually fix them.
 
@@ -72,7 +72,7 @@ That kind of judgement doesn't come from delegation. It comes from struggle.
 
 Learning hard things means feeling stupid for long periods. Many people quit before they hit the first rewarding milestone.
 
-AI can help here — not by replacing learning, but by getting someone to an early win that keeps them in the game.
+AI can help here - not by replacing learning, but by getting someone to an early win that keeps them in the game.
 
 ```
 Beginner starts coding

--- a/data/blog/big-tech-engineers-need-big-egos.mdx
+++ b/data/blog/big-tech-engineers-need-big-egos.mdx
@@ -51,7 +51,7 @@ The same engineer who needs a strong ego in technical work also needs to suppres
 
 An engineer may do excellent work, be correct on the merits, and still lose due to political context several layers above them. Projects can be cancelled late, priorities can reverse suddenly, and strong effort may go unrewarded.
 
-> At the end of the day, your job — the reason the company pays you — is to execute on your boss's and your boss's boss's plans, whether you agree with them or not.
+> At the end of the day, your job - the reason the company pays you - is to execute on your boss's and your boss's boss's plans, whether you agree with them or not.
 >
 > Sean Goedecke
 

--- a/data/blog/building-a-competitive-advantage.mdx
+++ b/data/blog/building-a-competitive-advantage.mdx
@@ -60,7 +60,7 @@ Once you've identified genuine high performers:
 
 ## Embracing the Boring Bits
 
-Here's where the advice diverges from typical career guidance: **actively seek out the boring work**. Documentation, incident response, training materials, cleanup tasks that everyone else avoids — dive in headfirst.
+Here's where the advice diverges from typical career guidance: **actively seek out the boring work**. Documentation, incident response, training materials, cleanup tasks that everyone else avoids - dive in headfirst.
 
 Why? Because these are often the tasks that create the most value but get the least recognition. When you're the person who consistently handles the unglamorous but critical work, you become indispensable. You also gain deep insights into how systems actually work, not just how they're supposed to work.
 
@@ -117,6 +117,6 @@ The ultimate measure is reaching a position where you can focus your efforts on 
 
 ## What's Next
 
-If you're early in your career, focus on the fundamentals: show up consistently, dig deep into understanding context, and don't be afraid of the boring work. If you're more experienced, remember that your role isn't just to solve technical problems — it's to help others navigate the complexity of building software in large organisations.
+If you're early in your career, focus on the fundamentals: show up consistently, dig deep into understanding context, and don't be afraid of the boring work. If you're more experienced, remember that your role isn't just to solve technical problems - it's to help others navigate the complexity of building software in large organisations.
 
 Either way, remember that **50% of success is just showing up**. The rest, you can figure out as you go.

--- a/data/blog/career-growth-stagnant-environment.mdx
+++ b/data/blog/career-growth-stagnant-environment.mdx
@@ -20,7 +20,7 @@ But when your ambition outpaces your environment, the friction gets exhausting u
 
 **Know what you want.** What skills? What impact? What's the long-term goal? A clear vision provides sustained motivation when the day-to-day feels like a treadmill.
 
-**Pick projects that compound.** Avoid "lily pad hopping" — jumping between disconnected tasks with no cumulative value. Each project should build on the last.
+**Pick projects that compound.** Avoid "lily pad hopping" - jumping between disconnected tasks with no cumulative value. Each project should build on the last.
 
 | Approach | Result After 2 Years |
 |----------|---------------------|
@@ -58,7 +58,7 @@ Sometimes the culture is fundamentally indifferent to growth. Talented engineers
 The signals aren't subtle:
 - Promotion criteria are opaque and always favour the same people
 - Your manager changes every six months and nobody remembers your goals
-- "We've always done it this way" — not because the old way is good, but because change is effort
+- "We've always done it this way" - not because the old way is good, but because change is effort
 - Senior engineers are coasting and the organisation rewards tenure over impact
 
 **Assess honestly.** Does leadership care about development? If not, you're fighting uphill. Do people get promoted for impact or for longevity? Are the senior engineers still learning, or are they curators of outdated expertise?

--- a/data/blog/closing-the-feedback-loop.mdx
+++ b/data/blog/closing-the-feedback-loop.mdx
@@ -1,5 +1,5 @@
 ---
-title: The Real AI Skill Isn't Prompting — It's Loop-Closing
+title: The Real AI Skill Isn't Prompting - It's Loop-Closing
 summary: |
   Engineers try AI tools 2-3 times, hit a wall, and walk away. They declare the tool useless and go back to manual work. After watching this pattern repeat across dozens of teams, I've realised the single biggest blocker to AI adoption isn't model quality or tool selection. It's the inability to close the feedback loop.
 date: "2026-02-15 18:00:44 +1000"
@@ -44,13 +44,13 @@ Initial Prompt -> AI Response -> Evaluate Output
 I spend 30-40 minutes talking to an AI to work through problems. That time investment is the core skill.
 
 **The steering process:**
-1. **Set context** — problem space, constraints, desired outcome
-2. **First attempt** — let it generate something
-3. **Evaluate** — what's right, wrong, missing
-4. **Steer** — specific feedback on gaps
-5. **Refine** — AI adjusts
-6. **Repeat** — until output meets requirements
-7. **Validate** — check contradictions, edge cases, missed requirements
+1. **Set context** - problem space, constraints, desired outcome
+2. **First attempt** - let it generate something
+3. **Evaluate** - what's right, wrong, missing
+4. **Steer** - specific feedback on gaps
+5. **Refine** - AI adjusts
+6. **Repeat** - until output meets requirements
+7. **Validate** - check contradictions, edge cases, missed requirements
 
 ## Real Example: Playbook YAML Generation
 
@@ -60,9 +60,9 @@ My instruction: *"When you create these files, capture myths, gaps, and contradi
 
 The first attempt is usually wrong in multiple ways. Events in the wrong order. Decisions attributed to the wrong people. Gaps where nothing happened but politics. Meetings that were cancelled. Similarly-named projects confused. A mess.
 
-Most people stop there. "AI can't do this kind of research." But the first attempt is never the final attempt. The next thirty minutes are steering: "This event is out of order — check the ticket dates." "That's the wrong person — search for the other one." "There's a gap between March and June. Search Slack for what happened during that period."
+Most people stop there. "AI can't do this kind of research." But the first attempt is never the final attempt. The next thirty minutes are steering: "This event is out of order - check the ticket dates." "That's the wrong person - search for the other one." "There's a gap between March and June. Search Slack for what happened during that period."
 
-By the seventh iteration, the timeline is accurate. By the ninth, it includes context you'd forgotten — a thread where the team discussed an approach and rejected it, which explains why the architecture looks the way it does. The final output isn't just correct. It's useful in ways you hadn't anticipated.
+By the seventh iteration, the timeline is accurate. By the ninth, it includes context you'd forgotten - a thread where the team discussed an approach and rejected it, which explains why the architecture looks the way it does. The final output isn't just correct. It's useful in ways you hadn't anticipated.
 
 Total time: 40 minutes. Manual research would have taken a day. The AI doesn't replace judgement. It amplifies the ability to apply that judgement across a large information space.
 
@@ -96,7 +96,7 @@ Specificity is everything. Diagnose the gap, don't just flag the symptom.
 
 Sprint pressure discourages 30-40 minute sessions. But spending 30 minutes upfront saves hours later. Feels like a luxury when deadlines are tight.
 
-The paradox is real. When you're busiest, you have the least time to invest in the skill that would save you time. But that's exactly when the payoff is highest. A production issue needs root cause analysis by Friday. The temptation is to just write it yourself — you know the system, two hours max. Or spend forty minutes with an agent: setting context, iterating, steering. The final output often catches edge cases you'd forgotten, structures the timeline more clearly, and takes forty minutes instead of two hours.
+The paradox is real. When you're busiest, you have the least time to invest in the skill that would save you time. But that's exactly when the payoff is highest. A production issue needs root cause analysis by Friday. The temptation is to just write it yourself - you know the system, two hours max. Or spend forty minutes with an agent: setting context, iterating, steering. The final output often catches edge cases you'd forgotten, structures the timeline more clearly, and takes forty minutes instead of two hours.
 
 ## Teaching Loop-Closing At Scale
 
@@ -120,7 +120,7 @@ Goal: make it teachable and repeatable.
 
 **Document case studies.** Full arc: initial problem, first attempt, steering conversation, final output, time saved. Example: *"How I generated 3 months of platform timeline in 40 minutes."*
 
-Teaching loop-closing works best through demonstration. Show the full arc: first attempt failing, steering through iterations, final success. Some adopt it immediately. Some take weeks to build the habit. Some never get it — they still treat AI like a search engine, expecting correct answers from single queries.
+Teaching loop-closing works best through demonstration. Show the full arc: first attempt failing, steering through iterations, final success. Some adopt it immediately. Some take weeks to build the habit. Some never get it - they still treat AI like a search engine, expecting correct answers from single queries.
 
 The difference isn't intelligence or technical skill. It's patience. The engineers who succeed are willing to be wrong five times before they're right. The ones who don't give up after the second attempt, every time. Loop-closing is a patience skill as much as a technical one.
 
@@ -128,9 +128,9 @@ The difference isn't intelligence or technical skill. It's patience. The enginee
 
 I've taught this pattern to groups of engineers through a structured enablement programme. The most effective format was hands-on workshops where participants brought their own problems and worked through them in real time.
 
-One pattern emerged consistently: the participants who struggled most were those who expected a "correct" way to prompt. They wanted the magic phrase that would make AI work perfectly. The ones who succeeded fastest were those who treated it as a conversation — trying, failing, adjusting, trying again.
+One pattern emerged consistently: the participants who struggled most were those who expected a "correct" way to prompt. They wanted the magic phrase that would make AI work perfectly. The ones who succeeded fastest were those who treated it as a conversation - trying, failing, adjusting, trying again.
 
-The programme proved something important: loop-closing can be taught, but not through documentation alone. It requires live demonstration, safe practice environments, and repeated exposure to the full arc of failure → steering → success. After running multiple sessions, we found that showing the full feedback loop in real-time — first attempt through iterative steering to final output — was more effective than any slide deck.
+The programme proved something important: loop-closing can be taught, but not through documentation alone. It requires live demonstration, safe practice environments, and repeated exposure to the full arc of failure → steering → success. After running multiple sessions, we found that showing the full feedback loop in real-time - first attempt through iterative steering to final output - was more effective than any slide deck.
 
 The metric that mattered wasn't how many people attended. It was how many kept using the tools after the session ended. The ones who internalised loop-closing stayed. The ones who didn't went back to manual methods within a week.
 

--- a/data/blog/dhhs-standards-didnt-change.mdx
+++ b/data/blog/dhhs-standards-didnt-change.mdx
@@ -1,7 +1,7 @@
 ---
 title: DHH's Standards Didn't Change, the Tools Did
 summary: |
-  David Heinemeier Hansson now works agent-first. But his philosophy of craft didn't flip — the tools finally got good enough to preserve taste while dramatically widening what feels economically possible to build. After mapping his latest thinking against my own experience with Claude Code, the inflection point wasn't model quality alone. It was the shift from intrusive autocomplete to delegation-based harnesses.
+  David Heinemeier Hansson now works agent-first. But his philosophy of craft didn't flip - the tools finally got good enough to preserve taste while dramatically widening what feels economically possible to build. After mapping his latest thinking against my own experience with Claude Code, the inflection point wasn't model quality alone. It was the shift from intrusive autocomplete to delegation-based harnesses.
 date: "2026-04-11 09:40:37 +1000"
 tags:
   - AI
@@ -22,7 +22,7 @@ DHH's resistance wasn't mainly ideological. He found autocomplete hostile becaus
 
 The distinction between autocomplete and agents is the difference between interruption and delegation. Autocomplete suggests six lines while you're building a mental model. You stop thinking, evaluate the suggestion, decide it's wrong, dismiss it, reconstruct your train of thought. The interruption costs more than the suggestion saves.
 
-Agents chunk the interaction differently. Intent, delegation, review. No interruptions mid-thought. The model quality threshold isn't about generating impressive code — it's about generating code that passes the merge test. Code that needs little or no alteration. Code that learns from corrections instead of repeating mistakes.
+Agents chunk the interaction differently. Intent, delegation, review. No interruptions mid-thought. The model quality threshold isn't about generating impressive code - it's about generating code that passes the merge test. Code that needs little or no alteration. Code that learns from corrections instead of repeating mistakes.
 
 The inflection point isn't that the technology is new. It's that it finally became teachable.
 
@@ -46,7 +46,7 @@ Inflection:   Stronger models produce code worth reviewing and merging
 
 Most useful part of the conversation isn't about models. It's about how 37signals builds products.
 
-Their designers aren't downstream spec-polishers. They help decide what to build, how it works, often implement HTML, CSS, and behaviour themselves. Early product teams are tiny — one programmer plus one or two designers — until the shape becomes clear.
+Their designers aren't downstream spec-polishers. They help decide what to build, how it works, often implement HTML, CSS, and behaviour themselves. Early product teams are tiny - one programmer plus one or two designers - until the shape becomes clear.
 
 AI rewards exactly this kind of organisation. When implementation gets cheaper, people who move fluidly between product judgement, interface design, and code become unusually powerful.
 
@@ -73,7 +73,7 @@ Gains don't hit everyone equally. Senior engineers, designers who can implement,
 
 If implementation becomes cheap but validation becomes the scarce skill, then the people who can validate become disproportionately valuable. That's not a temporary distortion. That's a new equilibrium.
 
-DHH is explicit that this acceleration is intoxicating enough to create burnout risk. The dopamine loop of rapid agentic output is real — the first week of serious agent use often produces more code than the previous month. The second week, velocity becomes addictive. The third week, the boundary between work and rest blurs because "the agent could finish this while I sleep." The productivity gain is real. The burnout risk is also real.
+DHH is explicit that this acceleration is intoxicating enough to create burnout risk. The dopamine loop of rapid agentic output is real - the first week of serious agent use often produces more code than the previous month. The second week, velocity becomes addictive. The third week, the boundary between work and rest blurs because "the agent could finish this while I sleep." The productivity gain is real. The burnout risk is also real.
 
 ## Summary
 

--- a/data/blog/how-to-rest-so-you-actually-recover.mdx
+++ b/data/blog/how-to-rest-so-you-actually-recover.mdx
@@ -58,7 +58,7 @@ The belief that constant thinking demonstrates care or competence is counter-pro
 Three changes enable detachment:
 1. **Honest acceptance** that humans cannot operate like machines
 2. **Non-negotiable routines** for relaxation and exercise, scheduled in advance
-3. **Reduced self-imposed pressure** — the work will be there tomorrow regardless
+3. **Reduced self-imposed pressure** - the work will be there tomorrow regardless
 
 ## The Four Dimensions of Recovery
 
@@ -73,7 +73,7 @@ Complete mental switch-off from work problems. Protecting routines. Avoiding aft
 ### 3. Mastery
 Learning something new with visible progress. Exercise progression. Dancing. Learning an instrument. Jigsaw puzzles. Cooking a new recipe.
 
-Crucially, mastery activities also trigger psychological detachment. It's easier to mentally switch off when engaged in something that demands focused attention on progress. Over time, mastery builds what researchers call a "relaxation asset" — a hobby that becomes an increasingly effective recovery mechanism the more you do it.
+Crucially, mastery activities also trigger psychological detachment. It's easier to mentally switch off when engaged in something that demands focused attention on progress. Over time, mastery builds what researchers call a "relaxation asset" - a hobby that becomes an increasingly effective recovery mechanism the more you do it.
 
 ### 4. Control
 Self-directed choice over non-work time. Even 15–20 minutes of a selfishly chosen activity creates recovery because the act of taking control is itself restorative. The activity doesn't need to be productive. It just needs to be yours.
@@ -89,7 +89,7 @@ Self-directed choice over non-work time. Even 15–20 minutes of a selfishly cho
 
 Despite knowing exercise improves energy, it still requires willpower to go when tired. The reason is prefrontal cortex fatigue.
 
-As neurotransmitters build up throughout the day, the prefrontal cortex — responsible for decision-making, planning, and self-regulation — becomes impaired. When fatigued, the brain develops a systematic bias toward decisions requiring minimal planning and effort.
+As neurotransmitters build up throughout the day, the prefrontal cortex - responsible for decision-making, planning, and self-regulation - becomes impaired. When fatigued, the brain develops a systematic bias toward decisions requiring minimal planning and effort.
 
 This effect is so reliable that decision patterns are a more accurate fatigue indicator than self-reported tiredness. When someone consistently chooses low-effort, low-planning options despite knowing better ones exist, the prefrontal cortex is fatigued.
 
@@ -113,7 +113,7 @@ Practical steps:
 
 4. **Remove pressure to commit fully.** Five minutes on a hobby builds it into a recovery asset over time. There is no right way as long as the activity provides value.
 
-5. **When too exhausted to choose:** Find the nearest natural area and spend 30 minutes there. Research on [soft fascination](https://en.wikipedia.org/wiki/Attention_restoration_theory) — a mechanism unique to natural environments — shows that effortless engagement with nature renews attention, energy, and working memory. Guidelines suggest approximately 30 minutes per session or 120 minutes per week cumulatively.
+5. **When too exhausted to choose:** Find the nearest natural area and spend 30 minutes there. Research on [soft fascination](https://en.wikipedia.org/wiki/Attention_restoration_theory) - a mechanism unique to natural environments - shows that effortless engagement with nature renews attention, energy, and working memory. Guidelines suggest approximately 30 minutes per session or 120 minutes per week cumulatively.
 
 ## Summary
 
@@ -121,7 +121,7 @@ Practical steps:
 - **Sleep doesn't cure cognitive fatigue.** Unresolved mental load carries into dreams and reduces sleep quality.
 - **Psychological detachment is the strongest predictor.** The ability to mentally switch off matters more than meditation or exercise.
 - **The recovery paradox is real.** People recover least when they need it most.
-- **Build relaxation assets.** Mastery hobbies compound — they get more restorative the longer you do them.
+- **Build relaxation assets.** Mastery hobbies compound - they get more restorative the longer you do them.
 - **Decide in advance, remove friction, show up.** Counter decision fatigue with planning, not willpower.
 
 ## What's Next

--- a/data/blog/just-talk-to-it.mdx
+++ b/data/blog/just-talk-to-it.mdx
@@ -33,7 +33,7 @@ Useful control prompts (short, human language):
 - "Give me a few options before making changes."
 - "Stop and summarise the likely blast radius."
 
-Surprisingly similar to managing humans. Best senior engineers are interruptible, communicative, predictable about scope. Agent management maps to engineering management — expectations, scoping, feedback cadence — not "prompt wizardry."
+Surprisingly similar to managing humans. Best senior engineers are interruptible, communicative, predictable about scope. Agent management maps to engineering management - expectations, scoping, feedback cadence - not "prompt wizardry."
 
 ## Parallel Agents Without Worktrees
 
@@ -76,7 +76,7 @@ Agent-written code drifts toward duplication and "good enough" unless you delibe
 
 Agent-written code drifts toward duplication and "good enough" unless you deliberately refactor. After months of heavy agent use, codebases accumulate multiple implementations of the same logic. None wrong. Each good enough for its feature. Collectively, a maintenance burden.
 
-The fix is scheduling: declare "refactor Fridays" — no new features, just cleanup. Consolidate duplication, remove dead code, fix lint rules, address deprecations. The agents do most of the refactoring work. You just decide what good looks like.
+The fix is scheduling: declare "refactor Fridays" - no new features, just cleanup. Consolidate duplication, remove dead code, fix lint rules, address deprecations. The agents do most of the refactoring work. You just decide what good looks like.
 
 Flips a common fear ("AI creates slop") into an operating model: slop is a *scheduling* problem, not inevitability.
 
@@ -100,4 +100,4 @@ Flips a common fear ("AI creates slop") into an operating model: slop is a *sche
 
 ## What's Next
 
-Next time you reach for an elaborate agent harness, ask whether a simple conversation would achieve the same result faster. Usually yes — if the model is strong enough and you're willing to steer.
+Next time you reach for an elaborate agent harness, ask whether a simple conversation would achieve the same result faster. Usually yes - if the model is strong enough and you're willing to steer.

--- a/data/blog/reigniting-the-flame.mdx
+++ b/data/blog/reigniting-the-flame.mdx
@@ -8,16 +8,16 @@ tags:
   - Homelab
   - Digital Garden
 draft: false
-summary: After five years away from regular web development, I'm diving back in with this new digital garden. Here's why I built it, who it's for (hint—maybe no one), and what you might find here. A rambling journey through my return to the front-end wilderness.
+summary: After five years away from regular web development, I'm diving back in with this new digital garden. Here's why I built it, who it's for (hint-maybe no one), and what you might find here. A rambling journey through my return to the front-end wilderness.
 ---
 
-I'm building this website after a five-year hiatus. Five years since I released my first template—a simple copy-paste job from GitHub back when Jekyll and GitHub Pages were the standard, before GitHub Actions was even a thing. It's wild to think how much has changed in the web development landscape since then. Frameworks have come and gone, entire paradigms have shifted, and here I am, trying to make sense of it all again.
+I'm building this website after a five-year hiatus. Five years since I released my first template-a simple copy-paste job from GitHub back when Jekyll and GitHub Pages were the standard, before GitHub Actions was even a thing. It's wild to think how much has changed in the web development landscape since then. Frameworks have come and gone, entire paradigms have shifted, and here I am, trying to make sense of it all again.
 
 Now it's probably time for me to stretch a muscle that hasn't been used in a while: front-end development. That part of my brain that deals with layouts, responsive design, and making things look pretty has been dormant for too long. I used to have opinions on CSS frameworks and JavaScript libraries, but lately? I've been too busy with other aspects of tech to keep up. This website is my re-entry vehicle.
 
 ## The Spark That Started It All
 
-Back in the day, I built websites here and there. Not many, really—I wasn't some prolific web developer churning out sites every weekend. The one that really stands out was a Laravel project—a passion project for a Garry's Mod gaming community called the [Gentleman's Gaming Society](https://ggs.sx). That site came from a friendship that's now lasted over 12 years (since 2014, if you're doing the math), which is pretty incredible when you think about it. A digital connection that outlasted most of my real-world ones.
+Back in the day, I built websites here and there. Not many, really-I wasn't some prolific web developer churning out sites every weekend. The one that really stands out was a Laravel project-a passion project for a Garry's Mod gaming community called the [Gentleman's Gaming Society](https://ggs.sx). That site came from a friendship that's now lasted over 12 years (since 2014, if you're doing the math), which is pretty incredible when you think about it. A digital connection that outlasted most of my real-world ones.
 
 Check out the Wayback Machine archives of the site:
 
@@ -32,7 +32,7 @@ Check out the Wayback Machine archives of the site:
 
 Note that this was before the days of Discord where we used forums like this site and TeamSpeak to communicate. 
 
-Throughout those years until 2021 - 2022, I kept iterating on it. Started with a simple PHP website from scratch—you know, the kind where you're mixing HTML and PHP tags in the same file like some kind of chaotic soup. Then I gradually graduated to Laravel and learned my way up from there. Models, views, controllers, database migrations—the whole MVC shebang. 
+Throughout those years until 2021 - 2022, I kept iterating on it. Started with a simple PHP website from scratch-you know, the kind where you're mixing HTML and PHP tags in the same file like some kind of chaotic soup. Then I gradually graduated to Laravel and learned my way up from there. Models, views, controllers, database migrations-the whole MVC shebang. 
 
 That spark I had back then? That feeling when a layout finally renders correctly or when a complex feature works exactly as intended? That's what I want to bring back in 2025 and beyond. It's like rediscovering an old hobby and realizing you still get the same joy from it.
 
@@ -53,15 +53,15 @@ Who am I really writing this for? Why would anyone care that I'm putting this ou
 
 Honestly? Probably no one. And that's completely okay.
 
-I think it's a good time to just put something out there in the open. Maybe someone will stumble across this site while looking for a solution to a problem they're having. Maybe they'll find useful bits of information—particularly about my homelab adventures and solutions I've white-knuckled my way through. 
+I think it's a good time to just put something out there in the open. Maybe someone will stumble across this site while looking for a solution to a problem they're having. Maybe they'll find useful bits of information-particularly about my homelab adventures and solutions I've white-knuckled my way through. 
 
 Instead of writing docs that sit forgotten in some private repository, I can share them here where they might actually help someone. We're in this era where everyone's trying to monetize their knowledge, slap ads on everything, or build a personal brand. I'm not interested in any of that. 
 
-This digital garden will remain ad-free and ego-free. I don't expect anyone to care about what's inside, but if you happen to like this stuff, that's a nice bonus. Consider it an extension of my GitHub profile, but with more context and personality—a place where code meets thoughts.
+This digital garden will remain ad-free and ego-free. I don't expect anyone to care about what's inside, but if you happen to like this stuff, that's a nice bonus. Consider it an extension of my GitHub profile, but with more context and personality-a place where code meets thoughts.
 
 ## The Tech Stack (Or How I Went Down the Rabbit Hole)
 
-I went fairly hog wild with technology for this site, using what's relevant for 2025—though we all know it'll probably be outdated in five years. That's just how web development works, isn't it? The framework you swear by today becomes tomorrow's legacy system.
+I went fairly hog wild with technology for this site, using what's relevant for 2025-though we all know it'll probably be outdated in five years. That's just how web development works, isn't it? The framework you swear by today becomes tomorrow's legacy system.
 
 I've tried to keep dependencies minimal, though. There are websites that have been around for years with barely any changes that still run fine. I'm not building a CMS or a dedicated back-end service just for a static site. That would be overkill, and frankly, I don't want to maintain it.
 
@@ -76,7 +76,7 @@ The design? A kitchen sink of patterns I've noticed across multiple portfolio we
 
 ## The Process (Or: How I Vibe-Coded a Website)
 
-I built this using all the trendy tools of today, including AI IDEs like WindSurf and Cursor. I've been essentially "vibe-coding" my way through almost the entire project—letting the tools suggest patterns and implementations while I focus on the overall direction. 
+I built this using all the trendy tools of today, including AI IDEs like WindSurf and Cursor. I've been essentially "vibe-coding" my way through almost the entire project-letting the tools suggest patterns and implementations while I focus on the overall direction. 
 
 There's a certain joy in letting the AI handle the boilerplate while you focus on the interesting problems. It's like pair programming with a partner who never gets tired or annoyed when you ask the same question for the fifth time. But there's also something lost when you're not crafting every line by hand. The intimacy with the codebase changes. The ownership feels different.
 
@@ -92,7 +92,7 @@ Hopefully eventually I can curate some of those notes into blog posts that peopl
 
 ## The Homelab Chronicles
 
-A significant chunk of what I'll be writing about here will involve my homelab setup. Over the years, I've built a modest home server infrastructure running various services—from media servers to home automation to networking experiments.
+A significant chunk of what I'll be writing about here will involve my homelab setup. Over the years, I've built a modest home server infrastructure running various services-from media servers to home automation to networking experiments.
 
 Much of this was learned through trial and error, late nights Googling obscure error messages, and the occasional "oh no" moment when something critical went down. I've documented most of it, but those docs are scattered across private repositories, note-taking apps, and sometimes just in my head.
 
@@ -104,7 +104,7 @@ I'm particularly looking forward to sharing some of my adventures in self-hostin
 
 If you do have something interesting in mind, please do reach out. I'm usually accessible through [LinkedIn](https://www.linkedin.com/in/johnnyhuy/) and other means like Discord if you try hard enough. I am busy at times with a good mix of whatever I have on my plate at the moment, but I'd be happy to keep in touch.
 
-This space will evolve as I share more about my projects, homelab adventures, and the occasional tech rambling. Consider this the beginning of something new—or rather, something old made new again. A return to building and sharing in the open, without the pressure of metrics or monetization.
+This space will evolve as I share more about my projects, homelab adventures, and the occasional tech rambling. Consider this the beginning of something new-or rather, something old made new again. A return to building and sharing in the open, without the pressure of metrics or monetization.
 
 Thanks for reading this far. If you're still here, you're either really bored or we might have similar interests. Either way, welcome to my little corner of the internet.
 

--- a/data/blog/selecting-great-engineers-beyond-technical-skills.mdx
+++ b/data/blog/selecting-great-engineers-beyond-technical-skills.mdx
@@ -14,7 +14,7 @@ draft: false
 
 Technical proficiency is merely a baseline. The attributes that separate good engineers from great ones are harder to interview for and easier to ignore.
 
-Most hiring processes overweight technical skills because they're measurable. Whiteboard problems. Take-home assignments. System design interviews. These filter for coding ability. They don't filter for rally capacity, communication, or learning agility — the attributes that determine whether someone elevates a team or merely fills a seat.
+Most hiring processes overweight technical skills because they're measurable. Whiteboard problems. Take-home assignments. System design interviews. These filter for coding ability. They don't filter for rally capacity, communication, or learning agility - the attributes that determine whether someone elevates a team or merely fills a seat.
 
 ## Rally Capacity: The Critical Differentiator
 
@@ -83,7 +83,7 @@ Engineers who thrive on action and impact can become deeply demotivated by exces
 3. **Visible impact:** The ability to see tangible outcomes from their work
 4. **Process vs progress:** Organisations that emphasise process adherence over delivery create friction
 
-Companies that provide freedom and agency — allowing engineers to take ownership and drive projects forward with minimal bureaucratic friction — attract and retain exceptional talent. The engineers who leave aren't always leaving for more money. Often they're leaving for more agency.
+Companies that provide freedom and agency - allowing engineers to take ownership and drive projects forward with minimal bureaucratic friction - attract and retain exceptional talent. The engineers who leave aren't always leaving for more money. Often they're leaving for more agency.
 
 ## How to Interview for It
 

--- a/data/blog/shipping-projects-at-big-tech.mdx
+++ b/data/blog/shipping-projects-at-big-tech.mdx
@@ -12,7 +12,7 @@ draft: false
 
 Most projects die. Not because the code's bad. Because the org never agreed it was done.
 
-I used to think shipping meant deploying. Tickets closed, PRs merged, CI green. That's the easy part. The hard part is convincing everyone — product, leadership, the team two levels up — that you actually solved the thing you said you'd solve.
+I used to think shipping meant deploying. Tickets closed, PRs merged, CI green. That's the easy part. The hard part is convincing everyone - product, leadership, the team two levels up - that you actually solved the thing you said you'd solve.
 
 ## Shipping Is Whatever the Org Says It Is
 
@@ -35,7 +35,7 @@ Left alone, every project drifts, gets blocked, or hits an invisible dependency 
 
 This pattern repeats everywhere. A project looks simple on paper. Three sprints. One engineer. Straightforward. Then you discover the security review wasn't scheduled, the dependency team has a six-week backlog, and the RFC never reached the people who needed to see it. Assumptions live in different Slack channels until someone asks the obvious question three weeks in.
 
-Someone has to drag it across the line. Usually one engineer who holds the whole picture in their head — not doing all the work, but noticing the missing review, the unowned dependency, the team that assumed someone else was handling it.
+Someone has to drag it across the line. Usually one engineer who holds the whole picture in their head - not doing all the work, but noticing the missing review, the unowned dependency, the team that assumed someone else was handling it.
 
 Rules that look rigid bend when the business actually needs movement. The trick is knowing when the business actually needs movement.
 
@@ -43,7 +43,7 @@ Rules that look rigid bend when the business actually needs movement. The trick 
 
 Strong engineers can jump into unfamiliar code, build a demo that kills three weeks of debate, or spot a requirement that can be safely simplified.
 
-I've seen teams spend months debating infrastructure choices with slide decks and benchmark data, neither side budging. The breakthrough usually comes from someone who stops talking and starts showing — a working prototype with real load tests, a demo that makes the trade-offs visible, a spike that answers the question in days instead of weeks.
+I've seen teams spend months debating infrastructure choices with slide decks and benchmark data, neither side budging. The breakthrough usually comes from someone who stops talking and starts showing - a working prototype with real load tests, a demo that makes the trade-offs visible, a spike that answers the question in days instead of weeks.
 
 The engineer who builds the prototype rarely gets credit in the project update. But people remember who moved things forward. The next time a hard project needs leadership, that's who gets asked.
 
@@ -51,13 +51,13 @@ The engineer who builds the prototype rarely gets credit in the project update. 
 
 Talk to product. Talk to design. Find where the project is actually stuck and apply your skill there.
 
-The pattern applies beyond software. Any complex project with multiple stakeholders, invisible dependencies, and unclear ownership follows the same dynamics. The code — or the document, or the campaign, or the product spec — is the easy part. The hard part is the organisational agreement that the problem is solved.
+The pattern applies beyond software. Any complex project with multiple stakeholders, invisible dependencies, and unclear ownership follows the same dynamics. The code - or the document, or the campaign, or the product spec - is the easy part. The hard part is the organisational agreement that the problem is solved.
 
 ## AI Helps Most With Speed and Unfamiliar Code
 
-Generative AI is great when you need to get from zero to something workable fast. New repo, new language, new tooling — it gets you oriented quickly.
+Generative AI is great when you need to get from zero to something workable fast. New repo, new language, new tooling - it gets you oriented quickly.
 
-But faster code just moves the bottleneck downstream. Review, testing, operational confidence — that's still on you.
+But faster code just moves the bottleneck downstream. Review, testing, operational confidence - that's still on you.
 
 | Area | AI Makes Easier | Still Your Problem |
 |------|-----------------|---------------------|
@@ -70,7 +70,7 @@ Keep humans focused on the final 20 percent where verification and judgement mat
 
 ## Internal Platforms Need Shipping Discipline Too
 
-Shipping discipline applies to internal tools, not just customer-facing products. I learned this building a developer experience platform — essentially an internal portal for engineering teams.
+Shipping discipline applies to internal tools, not just customer-facing products. I learned this building a developer experience platform - essentially an internal portal for engineering teams.
 
 The first version had a service catalog, some onboarding docs, and a few software templates. Technically deployed. But engineers didn't use it. It wasn't "shipped" because the org hadn't agreed it solved a real problem.
 
@@ -78,7 +78,7 @@ The shift came when we stopped adding features and started measuring outcomes. T
 
 Internal platforms die from feature bloat and unclear ownership. The ones that survive ship incrementally and measure obsessively. Each small release proves value. Each metric tells a story the org can understand.
 
-Another lesson from platform work: keeping scope bounded is harder than it sounds. A platform migration I was involved with kept growing — new requirements, new stakeholders, new edge cases. The breakthrough came when we explicitly defined what was *out* of scope and stuck to it. A green-field module with solid tests shipped faster than the grand rewrite that was still being designed six months later.
+Another lesson from platform work: keeping scope bounded is harder than it sounds. A platform migration I was involved with kept growing - new requirements, new stakeholders, new edge cases. The breakthrough came when we explicitly defined what was *out* of scope and stuck to it. A green-field module with solid tests shipped faster than the grand rewrite that was still being designed six months later.
 
 **For platform teams: ship a thin slice that solves one real problem, then measure.** The org will believe in the platform when they see a team save hours, not when they see an architecture diagram.
 

--- a/data/blog/software-engineering-at-the-tipping-point.mdx
+++ b/data/blog/software-engineering-at-the-tipping-point.mdx
@@ -18,11 +18,11 @@ The argument isn't that AI replaces developers. It's that AI applies 10x pressur
 
 ## Software Ecology: The Lens That Matters
 
-Bender introduces "software ecology" — the study of socio-technical ecosystems that produce software. The term matters because it forces systems-level thinking.
+Bender introduces "software ecology" - the study of socio-technical ecosystems that produce software. The term matters because it forces systems-level thinking.
 
 A socio-technical system combines people and technology. [Conway's Law](https://en.wikipedia.org/wiki/Conway%27s_law) states that organisations build technologies mirroring their internal communication structures. Engineering culture and technical choices are interlinked. They cannot be evaluated separately.
 
-An ecosystem is a dynamic network of interdependent actors characterised by emergent behaviour — properties visible only when the whole system is assembled, not in individual components. This means you cannot manage a forest by looking at individual trees. You have to see it as an ecosystem.
+An ecosystem is a dynamic network of interdependent actors characterised by emergent behaviour - properties visible only when the whole system is assembled, not in individual components. This means you cannot manage a forest by looking at individual trees. You have to see it as an ecosystem.
 
 The implication: changing technology without changing organisational structure has limited impact. And changing structure without understanding the technical consequences is equally flawed.
 
@@ -32,11 +32,11 @@ Google's developer ecosystem cannot be understood through technical choices alon
 
 The technical side: a [monorepo](https://research.google/pubs/large-scale-software-development-at-google/) with over two billion lines of code, [trunk-based development](https://abseil.io/resources/swe-book/html/ch16.html) with no branches, a universal build toolchain (Blaze), a global test automation platform running billions of tests daily, uniform compute environments, and a small set of core languages.
 
-The principle of **shared fate** guides this: all code in one repository means a security patch propagates to every application within a week. This enables large-scale changes (LSCs), where a single developer can modify millions of lines of code — a capability Google has had for over 15 years, predating AI.
+The principle of **shared fate** guides this: all code in one repository means a security patch propagates to every application within a week. This enables large-scale changes (LSCs), where a single developer can modify millions of lines of code - a capability Google has had for over 15 years, predating AI.
 
 Key insight: the [Software Engineering at Google](https://abseil.io/resources/swe-book/) book dedicates its first half to engineering culture because the technical choices cannot be understood without cultural context. Trade-offs reveal what an organisation actually values, not what it claims to value.
 
-A five-person startup would optimise differently — prioritising velocity and agility over extreme scale. Google's choices are not universal recommendations. They are manifestations of Google's specific constraints and values.
+A five-person startup would optimise differently - prioritising velocity and agility over extreme scale. Google's choices are not universal recommendations. They are manifestations of Google's specific constraints and values.
 
 ## The 10x Problem: What Happens When Productivity Jumps
 
@@ -71,7 +71,7 @@ Beyond capacity, several deeper problems emerge:
 
 **Integration testing** becomes the most critical quality strategy, yet most organisations remain dissatisfied with their integration testing setup.
 
-The "conjunction of booleans" — requiring every test to pass before shipping — becomes infeasible at million-test scale. Organisations will need statistical test selection strategies.
+The "conjunction of booleans" - requiring every test to pass before shipping - becomes infeasible at million-test scale. Organisations will need statistical test selection strategies.
 
 **Internal APIs** require hardening equivalent to public-facing systems because agents will discover and access whatever data is available. If internal APIs are not treated with public-level security, agentic systems will expose vulnerabilities.
 
@@ -83,7 +83,7 @@ The "conjunction of booleans" — requiring every test to pass before shipping �
 
 [DORA research on AI development](https://dora.dev/) found that AI amplifies existing fundamentals rather than replacing them.
 
-Teams with strong practices — good decision-making culture, solid technical strategies, effective collaboration, healthy codebases, clean release processes — apply AI amplification productively. Teams with weak fundamentals amplify their dysfunction at equal speed.
+Teams with strong practices - good decision-making culture, solid technical strategies, effective collaboration, healthy codebases, clean release processes - apply AI amplification productively. Teams with weak fundamentals amplify their dysfunction at equal speed.
 
 AI generates more of everything: more tests, more documentation, more code, and also more confusion. Amplification is a magnitude, not a direction.
 
@@ -111,7 +111,7 @@ Build good frameworks for agents to operate within. Prevent bad choices at scale
 
 Engineering is programming integrated over time. AI makes programming faster. It does not automatically make engineering faster.
 
-The organisations that win will not be those with the best AI tools. They will be those with the strongest fundamentals that AI can amplify. Culture, technical strategy, collaboration, security posture, code health, release process — these determine whether AI becomes a multiplier or a megaphone for dysfunction.
+The organisations that win will not be those with the best AI tools. They will be those with the strongest fundamentals that AI can amplify. Culture, technical strategy, collaboration, security posture, code health, release process - these determine whether AI becomes a multiplier or a megaphone for dysfunction.
 
 Focus on fundamentals first. Then deploy AI at scale.
 

--- a/data/blog/the-loopy-era-of-ai.mdx
+++ b/data/blog/the-loopy-era-of-ai.mdx
@@ -18,13 +18,13 @@ The deeper idea: the most valuable pattern isn't one helpful model. It's autonom
 
 The shift from single-session to orchestration is gradual then sudden. You start with one agent walking through features line by line. Eventually you have multiple sessions running: one researching documentation, one implementing a feature, one writing tests. You bounce between them like a conductor, except the musicians keep playing when you look away.
 
-Leave an agent running overnight on a refactoring task and come back to find completed work, passed tests, edge cases handled, and a detailed summary of changes. Not perfect — some optimisations unnecessarily complex — but done overnight what would have taken a full day. The feeling is simultaneously exhilarating and slightly disorienting. You're no longer the one doing the work. You're the one directing it.
+Leave an agent running overnight on a refactoring task and come back to find completed work, passed tests, edge cases handled, and a detailed summary of changes. Not perfect - some optimisations unnecessarily complex - but done overnight what would have taken a full day. The feeling is simultaneously exhilarating and slightly disorienting. You're no longer the one doing the work. You're the one directing it.
 
 ## Agentic Engineering Is Now Orchestration
 
 Karpathy describes a sharp shift where manual coding fell away and agent delegation became default. The skill isn't writing every line anymore. It's expressing intent clearly, splitting work into macro actions, and managing multiple agents across repos and tools.
 
-The limiting factor is increasingly you, not compute access. Mastery looks like running multiple agents in parallel — one on research, one on planning, one on implementation.
+The limiting factor is increasingly you, not compute access. Mastery looks like running multiple agents in parallel - one on research, one on planning, one on implementation.
 
 ```mermaid
 flowchart LR
@@ -35,13 +35,13 @@ flowchart LR
     E --> F[Human review and redirection]
 ```
 
-Token throughput is the new GPU utilisation. More leverage means more anxiety — unused model capacity feels like wasted opportunity. Review is still the bottleneck. A big diff still needs human eyes.
+Token throughput is the new GPU utilisation. More leverage means more anxiety - unused model capacity feels like wasted opportunity. Review is still the bottleneck. A big diff still needs human eyes.
 
 Karpathy says many agent failures are skill issues in instructions, memory, or decomposition rather than model limits. "Everything is skill issue," as he puts it.
 
 ## Persistent Loops: The Next Frontier
 
-Karpathy distinguishes ordinary agent sessions from "claw" systems — persistent loops that keep running in their own sandbox, accumulating memory, acting while you're away.
+Karpathy distinguishes ordinary agent sessions from "claw" systems - persistent loops that keep running in their own sandbox, accumulating memory, acting while you're away.
 
 AutoResearch applies this to AI research: agents modify training code, run experiments, keep only improvements.
 
@@ -59,9 +59,9 @@ flowchart TD
 
 Remove the human from the inner loop when the objective and metric are explicit. AutoResearch surprised Karpathy by finding useful optimisations in an already well-tuned repo.
 
-Use autonomous loops where metrics are clean, verification is cheap, and risk is bounded. Keep the editable surface small. Treat agent instructions as first-class artefacts — iterate, version, benchmark them.
+Use autonomous loops where metrics are clean, verification is cheap, and risk is bounded. Keep the editable surface small. Treat agent instructions as first-class artefacts - iterate, version, benchmark them.
 
-Persistent loops work where the objective and metric are explicit. A test suite with a clear goal — reduce runtime without decreasing coverage — and an unambiguous metric — total seconds — is ideal. The loop modifies setup code, runs a subset, measures time, keeps improvements.
+Persistent loops work where the objective and metric are explicit. A test suite with a clear goal - reduce runtime without decreasing coverage - and an unambiguous metric - total seconds - is ideal. The loop modifies setup code, runs a subset, measures time, keeps improvements.
 
 Over a weekend, it might find optimisations you wouldn't have considered: parallelising test data setup, replacing database fixtures with in-memory mocks, subtle changes to state cleanup between runs. The total improvement might be 30-40% faster tests. Review each change on Monday morning. Some straightforward merges. Some requiring adjustment because the loop optimised for the metric in ways that harm readability.
 
@@ -101,7 +101,7 @@ Digital work transforms faster than robotics because bits are easier to copy and
 
 On education: explanatory work increasingly routes through agents. Humans contribute the irreducible insights, curriculum shape, and conceptual compression.
 
-Build for agent consumption as well as human consumption — docs, APIs, teaching materials. Focus human effort on the insight agents can't discover themselves.
+Build for agent consumption as well as human consumption - docs, APIs, teaching materials. Focus human effort on the insight agents can't discover themselves.
 
 ## From Pilot to Scale: What Actually Works
 
@@ -111,7 +111,7 @@ I ran a pilot programme with one team to test agentic development at scale. Five
 
 But the numbers don't tell the whole story. Four learnings emerged that now shape how we scale:
 
-**Maturity beats usage.** Teams that succeeded didn't just adopt the tools — they developed practices around them. Code review standards, ticket sizing discipline, workflow conventions. The tool was the enabler. The maturity was the differentiator.
+**Maturity beats usage.** Teams that succeeded didn't just adopt the tools - they developed practices around them. Code review standards, ticket sizing discipline, workflow conventions. The tool was the enabler. The maturity was the differentiator.
 
 **The bottleneck shifts.** When generation gets fast, review becomes the constraint. Teams that didn't adjust their review practices saw backlogs build up. The solution wasn't more reviewers. It was smaller scoped work and tighter feedback loops.
 


### PR DESCRIPTION
## What

Replaced em-dashes with hyphens across all 17 blog posts for consistent punctuation style.

## Files Changed

- 17 blog posts in data/blog/
- No content changes, only punctuation standardisation

## Verification

- [x] No em-dashes remain in any blog post
- [x] Skill file also updated (separate commit in one-obsidian repo)