### PR TITLE
fix: remove bold-as-speech and key:value patterns from posts

### DIFF
--- a/data/blog/closing-the-feedback-loop.mdx
+++ b/data/blog/closing-the-feedback-loop.mdx
@@ -86,9 +86,9 @@ Most engineers drop off after 2 attempts. I persist through 5-10+.
 
 Most engineers say "this is wrong" without saying what or why.
 
-**Ineffective:** *"This doesn't work."*
+Bad example: *"This doesn't work."*
 
-**Effective:** *"This contradicts the Slack message from 15 Jan where we decided TrueFoundry over LiteLLM. Search Slack for that decision and update the timeline. Also check for other contradictions between Slack and Confluence."*
+Good example: *"This contradicts the Slack message from 15 Jan where we decided TrueFoundry over LiteLLM. Search Slack for that decision and update the timeline. Also check for other contradictions between Slack and Confluence."*
 
 Specificity is everything. Diagnose the gap, don't just flag the symptom.
 
@@ -100,7 +100,7 @@ The paradox is real. When you're busiest, you have the least time to invest in t
 
 ## Teaching Loop-Closing At Scale
 
-Goal: make it teachable and repeatable.
+The goal is to make it teachable and repeatable.
 
 ### Steering Language
 
@@ -139,7 +139,8 @@ The metric that mattered wasn't how many people attended. It was how many kept u
 
 ## Measuring Success
 
-**Someone has learned it when they:**
+### Signs Someone Has Learned It
+
 - Continue past 3 attempts without frustration
 - Provide detailed feedback on what's wrong and why
 - Know when to steer vs restart
@@ -147,7 +148,8 @@ The metric that mattered wasn't how many people attended. It was how many kept u
 - Trust the process when early attempts fail
 - Can explain their steering approach to others
 
-**Someone hasn't when they:**
+### Signs Someone Hasn't
+
 - Give up early: "I tried twice, it doesn't work"
 - Give vague feedback: "This is wrong" without specifics
 - Blame the tool: "AI is useless for this"

--- a/data/blog/dhhs-standards-didnt-change.mdx
+++ b/data/blog/dhhs-standards-didnt-change.mdx
@@ -31,7 +31,7 @@ This matters for adoption curves. Early autocomplete frustrated experienced engi
 ```
 Pre 2025:    AI feels important but coding UX is irritating
 Early phase: Chat interfaces useful for tutoring
-Autocomplete: Tab completion feels intrusive and low trust
+Mid phase:   Tab completion feels intrusive and low trust
 Late 2025:   Agent harnesses become viable, terminal workflow clicks
 Inflection:   Stronger models produce code worth reviewing and merging
 2026:        Agent first becomes default for new work

--- a/data/blog/how-to-rest-so-you-actually-recover.mdx
+++ b/data/blog/how-to-rest-so-you-actually-recover.mdx
@@ -113,7 +113,7 @@ Practical steps:
 
 4. **Remove pressure to commit fully.** Five minutes on a hobby builds it into a recovery asset over time. There is no right way as long as the activity provides value.
 
-5. **When too exhausted to choose:** Find the nearest natural area and spend 30 minutes there. Research on [soft fascination](https://en.wikipedia.org/wiki/Attention_restoration_theory) - a mechanism unique to natural environments - shows that effortless engagement with nature renews attention, energy, and working memory. Guidelines suggest approximately 30 minutes per session or 120 minutes per week cumulatively.
+5. **When too exhausted to choose.** Find the nearest natural area and spend 30 minutes there. Research on [soft fascination](https://en.wikipedia.org/wiki/Attention_restoration_theory) - a mechanism unique to natural environments - shows that effortless engagement with nature renews attention, energy, and working memory. Guidelines suggest approximately 30 minutes per session or 120 minutes per week cumulatively.
 
 ## Summary
 

--- a/data/blog/just-talk-to-it.mdx
+++ b/data/blog/just-talk-to-it.mdx
@@ -49,7 +49,7 @@ Two requirements:
 
 Strongest tactical argument: many MCPs are "a CLI wrapped in tokens." If the model can call `gh` or any known CLI, it discovers usage via `--help` and you avoid injecting large tool descriptions into context.
 
-**Context tax:** Every token describing tools is a token not spent reasoning about your code. MCP definitions are recurring fixed cost. CLI usage is often in world knowledge already.
+Every token describing tools is a token not spent reasoning about your code. MCP definitions are recurring fixed cost. CLI usage is often in world knowledge already.
 
 Heuristic:
 - Stable, discoverable (`--help`), commonly known tool? Prefer CLI.


### PR DESCRIPTION
## What

Applied natural writing style rules to blog posts:

- Replaced bold-as-speech labels with plain text or H3 headers
- Removed key:value lead-ins from prose sentences
- Kept structural bold for category labels in lists and table rows

## Files Changed

- closing-the-feedback-loop.mdx
- dhhs-standards-didnt-change.mdx
- how-to-rest-so-you-actually-recover.mdx
- just-talk-to-it.mdx

## Verification

- [x] No more bold-as-speech dialogue labels
- [x] No more key:value lead-ins in prose
- [x] Structural bold preserved where it serves real emphasis