### PR TITLE
fix: remove key:value lead-ins and overused colons from posts

### DIFF
--- a/data/blog/ai-product-engineering-lego-blocks.mdx
+++ b/data/blog/ai-product-engineering-lego-blocks.mdx
@@ -106,7 +106,7 @@ We chose a hybrid: buy the gateway, build the SDK. The gateway handled model rou
 
 This proved valuable when we later switched gateway vendors. The applications on top didn't change. The SDK absorbed the migration. The primitive - a consistent interface for AI interactions - outlasted the implementation.
 
-The lesson: build where your unique context matters. Buy where the problem is already solved. The boundary moves as the market matures.
+Build where your unique context matters. Buy where the problem is already solved. The boundary moves as the market matures.
 
 ### The Copy-Paste Trap in Practice
 

--- a/data/blog/closing-the-feedback-loop.mdx
+++ b/data/blog/closing-the-feedback-loop.mdx
@@ -56,7 +56,7 @@ I spend 30-40 minutes talking to an AI to work through problems. That time inves
 
 I used this to generate a platform architecture timeline. AI with MCP tools searched Slack, Confluence, and Jira directly, then generated YAML with timestamped events.
 
-My instruction: *"When you create these files, capture myths, gaps, and contradictions."*
+I told it: *"When you create these files, capture myths, gaps, and contradictions."*
 
 The first attempt is usually wrong in multiple ways. Events in the wrong order. Decisions attributed to the wrong people. Gaps where nothing happened but politics. Meetings that were cancelled. Similarly-named projects confused. A mess.
 

--- a/data/blog/dhhs-standards-didnt-change.mdx
+++ b/data/blog/dhhs-standards-didnt-change.mdx
@@ -67,8 +67,6 @@ AI makes this model more viable because the designer doesn't need to learn React
 
 ## Gains Accrue Unevenly
 
-Sharpest implication: gains don't hit everyone equally. Senior engineers, designers who can implement, generalists who validate output become more leveraged first. Junior-heavy pipelines and execution-only roles look more fragile.
-
 Gains don't hit everyone equally. Senior engineers, designers who can implement, generalists who validate output become more leveraged first. Junior-heavy pipelines and execution-only roles look more fragile.
 
 If implementation becomes cheap but validation becomes the scarce skill, then the people who can validate become disproportionately valuable. That's not a temporary distortion. That's a new equilibrium.

--- a/data/blog/just-talk-to-it.mdx
+++ b/data/blog/just-talk-to-it.mdx
@@ -26,7 +26,7 @@ Blast radius = expected scope of a change (files touched, time, risk). Throw man
 
 Blast radius gets out of control fast. Ask an agent to "refactor the authentication system" and three hours later it's touched seventeen files, renamed functions that other services depend on, introduced subtle bugs that tests don't catch. The changes can't be reviewed meaningfully because the blast radius is too large. The only option is to revert and start over with smaller, scoped requests.
 
-The rule: if progress time or touched files exceed your mental estimate, interrupt immediately and ask for a status update. Keeps the agent aligned. Prevents it from "solving the wrong problem correctly."
+If progress time or touched files exceed your mental estimate, interrupt immediately and ask for a status update. Keeps the agent aligned. Prevents it from "solving the wrong problem correctly."
 
 Useful control prompts (short, human language):
 - "What's the status and what files have you changed so far?"

--- a/data/blog/software-engineering-at-the-tipping-point.mdx
+++ b/data/blog/software-engineering-at-the-tipping-point.mdx
@@ -24,17 +24,17 @@ A socio-technical system combines people and technology. [Conway's Law](https://
 
 An ecosystem is a dynamic network of interdependent actors characterised by emergent behaviour - properties visible only when the whole system is assembled, not in individual components. This means you cannot manage a forest by looking at individual trees. You have to see it as an ecosystem.
 
-The implication: changing technology without changing organisational structure has limited impact. And changing structure without understanding the technical consequences is equally flawed.
+Changing technology without changing organisational structure has limited impact. Changing structure without understanding the technical consequences is equally flawed.
 
 ## Google's Case Study: Culture and Infrastructure as One System
 
 Google's developer ecosystem cannot be understood through technical choices alone. The culture is deeply engineering-led: transparency, helpfulness, blameless postmortems, standardisation, continuous improvement, automation over toil.
 
-The technical side: a [monorepo](https://research.google/pubs/large-scale-software-development-at-google/) with over two billion lines of code, [trunk-based development](https://abseil.io/resources/swe-book/html/ch16.html) with no branches, a universal build toolchain (Blaze), a global test automation platform running billions of tests daily, uniform compute environments, and a small set of core languages.
+The technical side is a [monorepo](https://research.google/pubs/large-scale-software-development-at-google/) with over two billion lines of code, [trunk-based development](https://abseil.io/resources/swe-book/html/ch16.html) with no branches, a universal build toolchain (Blaze), a global test automation platform running billions of tests daily, uniform compute environments, and a small set of core languages.
 
 The principle of **shared fate** guides this: all code in one repository means a security patch propagates to every application within a week. This enables large-scale changes (LSCs), where a single developer can modify millions of lines of code - a capability Google has had for over 15 years, predating AI.
 
-Key insight: the [Software Engineering at Google](https://abseil.io/resources/swe-book/) book dedicates its first half to engineering culture because the technical choices cannot be understood without cultural context. Trade-offs reveal what an organisation actually values, not what it claims to value.
+The [Software Engineering at Google](https://abseil.io/resources/swe-book/) book dedicates its first half to engineering culture because the technical choices cannot be understood without cultural context. Trade-offs reveal what an organisation actually values, not what it claims to value.
 
 A five-person startup would optimise differently - prioritising velocity and agility over extreme scale. Google's choices are not universal recommendations. They are manifestations of Google's specific constraints and values.
 

--- a/data/blog/the-loopy-era-of-ai.mdx
+++ b/data/blog/the-loopy-era-of-ai.mdx
@@ -99,7 +99,7 @@ Software demand might rise as creation gets cheaper. People outside frontier lab
 
 Digital work transforms faster than robotics because bits are easier to copy and test than atoms.
 
-On education: explanatory work increasingly routes through agents. Humans contribute the irreducible insights, curriculum shape, and conceptual compression.
+Explanatory work increasingly routes through agents. Humans contribute the irreducible insights, curriculum shape, and conceptual compression.
 
 Build for agent consumption as well as human consumption - docs, APIs, teaching materials. Focus human effort on the insight agents can't discover themselves.
 


### PR DESCRIPTION
## What

Applied natural writing style rules to remove key:value lead-ins and overused colons:

- 'The implication:' → full sentence
- 'The technical side:' → 'The technical side is'
- 'Key insight:' → removed, sentence stands alone
- 'On education:' → removed, sentence stands alone
- 'Sharpest implication:' → removed duplicate (clean version already existed)
- 'The lesson:' → removed, sentence stands alone
- 'The rule:' → removed, sentence stands alone
- 'My instruction:' → 'I told it:'

## Files Changed

- ai-product-engineering-lego-blocks.mdx
- closing-the-feedback-loop.mdx
- dhhs-standards-didnt-change.mdx
- just-talk-to-it.mdx
- software-engineering-at-the-tipping-point.mdx
- the-loopy-era-of-ai.mdx