### PR TITLE
feat: polish, accessibility, mermaid theme, llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ public/feed.xml
 # search
 public/search.json
 
+# llms.txt and markdown post copies
+public/llms.txt
+public/blog/
+
 # misc
 .DS_Store
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -416,7 +416,8 @@
 }
 
 .prose table {
-  @apply mb-6 w-full border-collapse text-sm md:text-base;
+  @apply mb-6 w-full border-collapse;
+  font-size: inherit;
 }
 
 .prose thead th {
@@ -835,6 +836,17 @@ textarea:focus,
 textarea:focus-visible {
   --tw-ring-shadow: 0 0 #0000 !important;
   box-shadow: none !important;
+}
+
+/* Restore a visible focus indicator for keyboard users */
+a:focus-visible,
+button:focus-visible,
+[role='button']:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--color-yellow-500) !important;
+  outline-offset: 2px !important;
 }
 
 /* --- Dark mode prose inversion --- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,8 +90,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           disableTransitionOnChange={false}
         >
           <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col border-x">
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-yellow-500 focus:px-4 focus:py-2 focus:font-mono focus:text-sm focus:text-gray-900"
+            >
+              Skip to content
+            </a>
             <Navbar />
-            <main className="flex-1">{children}</main>
+            <main id="main-content" className="flex-1">{children}</main>
             <Footer />
           </div>
         </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,17 +26,14 @@ export default function Home() {
           <CloudPattern className="absolute inset-0" animated />
         </div>
         <div className="relative px-6 pt-20 pb-16 md:pt-24">
-          <div className="mb-8 flex items-center gap-5">
+          <div className="mb-8 flex items-center gap-4">
             <Image
               src={Me}
               alt={profile.name}
-              className="h-10 w-10 border object-cover grayscale md:h-12 md:w-12"
+              className="h-10 w-10 rounded-full border object-cover grayscale md:h-12 md:w-12"
               priority
             />
-            <div>
-              <p className="mono-label mb-1">{profile.title}</p>
-              <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{profile.name}</h1>
-            </div>
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{profile.name}</h1>
           </div>
           <p className="mb-8 max-w-prose text-lg leading-relaxed text-gray-600 dark:text-gray-300">
             {profile.bio}

--- a/components/blog-post.tsx
+++ b/components/blog-post.tsx
@@ -40,12 +40,16 @@ export function BlogPost({ post }: BlogPostProps) {
         all posts
       </Link>
 
-      <article>
+      <article itemScope itemType="https://schema.org/BlogPosting">
         <header className="mb-10 border-b pb-10 md:mb-12">
-          <h1 className="mb-6 text-3xl font-bold tracking-tight md:text-4xl">{post.title}</h1>
+          <h1 itemProp="headline" className="mb-6 text-3xl font-bold tracking-tight md:text-4xl">
+            {post.title}
+          </h1>
 
           <p className="mono-label mb-6">
-            <time dateTime={post.date}>{isoDate}</time>
+            <time dateTime={post.date} itemProp="datePublished">
+              {isoDate}
+            </time>
             {formattedRelativeDate ? ` · ${formattedRelativeDate}` : ''}
             {post.readingTime?.text ? ` · ${post.readingTime.text}` : ''}
           </p>
@@ -71,7 +75,10 @@ export function BlogPost({ post }: BlogPostProps) {
           </div>
         )}
 
-        <div className="prose prose-lg dark:prose-invert prose-headings:scroll-mt-20 max-w-none">
+        <div
+          itemProp="articleBody"
+          className="prose prose-lg dark:prose-invert prose-headings:scroll-mt-20 max-w-none"
+        >
           <MDXLayoutRenderer code={post.body.code} components={components} />
         </div>
       </article>

--- a/components/mermaid-diagram.tsx
+++ b/components/mermaid-diagram.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import mermaid from 'mermaid'
 import { useTheme } from 'next-themes'
 
@@ -9,27 +9,78 @@ interface MermaidDiagramProps {
   className?: string
 }
 
+const lightVars = {
+  background: 'transparent',
+  primaryColor: '#f2f2f2',
+  primaryBorderColor: '#737373',
+  primaryTextColor: '#0d0d0d',
+  secondaryColor: '#e5e5e5',
+  tertiaryColor: '#fafafa',
+  lineColor: '#595959',
+  textColor: '#0d0d0d',
+  nodeBorder: '#595959',
+  clusterBkg: '#f7f7f7',
+  clusterBorder: '#a3a3a3',
+  edgeLabelBackground: '#ffffff',
+  actorBkg: '#f2f2f2',
+  actorBorder: '#595959',
+  actorTextColor: '#0d0d0d',
+  signalColor: '#0d0d0d',
+  signalTextColor: '#0d0d0d',
+  labelBoxBkgColor: '#f2f2f2',
+  labelTextColor: '#0d0d0d',
+  loopTextColor: '#404040',
+  noteBkgColor: '#fef08a',
+  noteTextColor: '#0d0d0d',
+  noteBorderColor: '#a16207',
+}
+
+const darkVars = {
+  background: 'transparent',
+  primaryColor: '#1a1a1a',
+  primaryBorderColor: '#737373',
+  primaryTextColor: '#e8e8e8',
+  secondaryColor: '#262626',
+  tertiaryColor: '#141414',
+  lineColor: '#a3a3a3',
+  textColor: '#e8e8e8',
+  nodeBorder: '#a3a3a3',
+  clusterBkg: '#1a1a1a',
+  clusterBorder: '#525252',
+  edgeLabelBackground: '#141414',
+  actorBkg: '#1a1a1a',
+  actorBorder: '#a3a3a3',
+  actorTextColor: '#e8e8e8',
+  signalColor: '#e8e8e8',
+  signalTextColor: '#e8e8e8',
+  labelBoxBkgColor: '#1a1a1a',
+  labelTextColor: '#e8e8e8',
+  loopTextColor: '#a3a3a3',
+  noteBkgColor: '#a16207',
+  noteTextColor: '#0d0d0d',
+  noteBorderColor: '#eab308',
+}
+
 export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
   const [svgContent, setSvgContent] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
   const { resolvedTheme } = useTheme()
-  const mermaidRef = useRef<HTMLDivElement>(null)
-  const uniqueId = useRef(`mermaid-${Math.random().toString(36).substring(2, 11)}`)
+  const uniqueId = `mermaid-${useId().replace(/:/g, '')}`
 
   useEffect(() => {
-    // Configure Mermaid with theme support
-    const theme = resolvedTheme === 'dark' ? 'dark' : 'default'
+    const isDark = resolvedTheme === 'dark'
 
-    try {
-      mermaid.initialize({
-        startOnLoad: false,
-        theme,
-        securityLevel: 'loose',
-        fontFamily: 'inherit',
-      })
-    } catch (err) {
-      console.error('Mermaid initialization error:', err)
-    }
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'base',
+      themeVariables: {
+        ...(isDark ? darkVars : lightVars),
+        fontFamily: 'var(--font-plex-mono), ui-monospace, monospace',
+        fontSize: '14px',
+      },
+      flowchart: { curve: 'linear', htmlLabels: true },
+      securityLevel: 'loose',
+    })
 
     const renderChart = async () => {
       if (!chart || typeof chart !== 'string' || chart.trim() === '') {
@@ -39,28 +90,21 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
 
       try {
         setError(null)
-
-        // Clean up the chart content
-        const cleanChart = chart.trim()
-
-        // Render the Mermaid diagram
-        const { svg } = await mermaid.render(uniqueId.current, cleanChart)
+        const { svg } = await mermaid.render(uniqueId, chart.trim())
         setSvgContent(svg)
       } catch (err) {
         console.error('Mermaid rendering error:', err)
-        setError(
-          `Failed to render diagram: ${err instanceof Error ? err.message : 'Unknown error'}`
-        )
+        setError(`Failed to render diagram: ${err instanceof Error ? err.message : 'Unknown error'}`)
       }
     }
 
     renderChart()
-  }, [chart, resolvedTheme])
+  }, [chart, resolvedTheme, uniqueId])
 
   if (error) {
     return (
-      <div className="rounded-md border border-red-500 bg-red-100 p-4 text-red-800 dark:bg-red-900/20 dark:text-red-100">
-        <p className="font-medium">Error rendering diagram</p>
+      <div className="border border-red-500 p-4 text-red-800 dark:text-red-200">
+        <p className="font-mono text-sm font-medium">Error rendering diagram</p>
         <pre className="mt-2 overflow-x-auto text-sm">{error}</pre>
         <pre className="mt-2 overflow-x-auto text-sm">{chart}</pre>
       </div>
@@ -68,12 +112,12 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
   }
 
   return (
-    <div className={`mermaid-diagram overflow-auto ${className}`}>
+    <div className={`mermaid-diagram overflow-auto ${className}`} role="img" aria-label="Diagram">
       {svgContent ? (
         <div dangerouslySetInnerHTML={{ __html: svgContent }} />
       ) : (
-        <div ref={mermaidRef} className="flex h-20 items-center justify-center">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
+        <div className="flex h-20 items-center justify-center">
+          <span className="mono-label">rendering diagram</span>
         </div>
       )}
     </div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,7 @@ const Navbar = () => {
             <Link
               key={link.path}
               href={link.path}
+              aria-current={isActive(link.path) ? 'page' : undefined}
               className={`font-mono text-sm tracking-wide lowercase transition-colors ${
                 isActive(link.path)
                   ? 'text-gray-900 dark:text-gray-100'

--- a/data/blog/closing-the-feedback-loop.mdx
+++ b/data/blog/closing-the-feedback-loop.mdx
@@ -52,6 +52,17 @@ The steering process:
 6. **Repeat** - until output meets requirements
 7. **Validate** - check contradictions, edge cases, missed requirements
 
+```mermaid
+flowchart LR
+    A[Set context] --> B[First attempt]
+    B --> C[Evaluate]
+    C --> D[Steer]
+    D --> E[Refine]
+    E -->|not there yet| C
+    E -->|meets requirements| F[Validate]
+    F --> G[Ship it]
+```
+
 ## Real Example: Playbook YAML Generation
 
 I used this to generate a platform architecture timeline. AI with MCP tools searched Slack, Confluence, and Jira directly, then generated YAML with timestamped events.

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "dev": "concurrently \"contentlayer2 dev\" \"next dev --turbopack\"",
     "build": "contentlayer2 build && next build",
-    "postbuild": "pnpm generate-sitemap && pnpm generate-rss && pnpm generate-robots",
+    "postbuild": "pnpm generate-sitemap && pnpm generate-rss && pnpm generate-robots && pnpm generate-llms",
     "contentlayer": "contentlayer2 build",
     "start": "next start",
     "lint": "eslint .",
     "postinstall": "contentlayer2 build",
     "generate-sitemap": "node --no-warnings scripts/generate-sitemap.mjs",
     "generate-rss": "node --no-warnings scripts/rss.mjs",
-    "generate-robots": "node --no-warnings scripts/generate-robots.mjs"
+    "generate-robots": "node --no-warnings scripts/generate-robots.mjs",
+    "generate-llms": "node --no-warnings scripts/generate-llms.mjs"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.4.0",

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -1,0 +1,64 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, '..');
+
+const outputFolder = process.env.EXPORT ? 'out' : 'public';
+
+async function generateLlms() {
+  const siteMetadataPath = path.join(projectRoot, 'data', 'siteMetadata.js');
+  const { default: siteMetadata } = await import(siteMetadataPath);
+  const baseUrl = siteMetadata.siteUrl;
+
+  const contentlayerPath = path.join(projectRoot, '.contentlayer/generated/index.mjs');
+  const { allBlogs } = await import(contentlayerPath);
+  const posts = [...allBlogs].sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  // Markdown versions of each post at /blog/<slug>.md
+  const blogOutDir = path.join(projectRoot, outputFolder, 'blog');
+  mkdirSync(blogOutDir, { recursive: true });
+  for (const post of posts) {
+    const body = post.body.raw
+      .split('\n')
+      .filter((line) => !/^import\s/.test(line) && !/^export\s/.test(line))
+      .join('\n')
+      .trim();
+    const md = [
+      `# ${post.title}`,
+      '',
+      `Published: ${post.date}`,
+      ...(post.tags?.length ? [`Tags: ${post.tags.join(', ')}`] : []),
+      '',
+      body,
+      '',
+    ].join('\n');
+    writeFileSync(path.join(blogOutDir, `${post.slug}.md`), md);
+  }
+
+  const llms = [
+    '# Johnny Huynh',
+    '',
+    `> ${siteMetadata.description}`,
+    '',
+    'Personal blog of Johnny Huynh, a builder of platforms and tools. Posts cover software engineering, AI tooling, and ways of working.',
+    '',
+    '## Blog',
+    ...posts.map((p) => `- [${p.title}](${baseUrl}/blog/${p.slug}.md): ${p.summary ?? ''}`),
+    '',
+    '## Pages',
+    `- [Home](${baseUrl})`,
+    `- [Blog index](${baseUrl}/blog)`,
+    `- [Site version archive](${baseUrl}/archive)`,
+    `- [Source code](${siteMetadata.siteRepo})`,
+    '',
+  ];
+  writeFileSync(path.join(projectRoot, outputFolder, 'llms.txt'), llms.join('\n'));
+  console.log(`llms.txt and ${posts.length} markdown posts generated in ${outputFolder}/`);
+}
+
+generateLlms().catch((error) => {
+  console.error('Error generating llms.txt:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Hero: BUILDER label removed (was repeating the bio), portrait is now mini and rounded
- Tables: body font now matches the prose font size
- Reader views: schema.org BlogPosting microdata on post pages (headline, datePublished, articleBody)
- Accessibility: restored visible focus outlines (globals previously removed them), skip-to-content link, aria-current on nav links
- Mermaid: site-consistent base theme (gray palette, IBM Plex Mono, sharp) in light and dark; added a steering-loop diagram to the feedback loop post
- llms.txt: /llms.txt plus /blog/<slug>.md markdown versions of every post, generated at postbuild

## Consequences

- llms.txt and .md files are generated artifacts (gitignored locally, written to out/ in CI)

## Testing

- pnpm build passes; eslint clean on changed files
- Screenshots verified: home hero, mermaid diagram in light and dark
- out/llms.txt and out/blog/*.md contents checked