### PR TITLE
feat: add Umami analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css'
 import Navbar from '@/components/navbar'
 import Footer from '@/components/footer'
 import { ThemeProvider } from '@/components/theme-provider'
+import { Analytics, type AnalyticsConfig } from 'pliny/analytics'
 import siteMetadata from '@/data/siteMetadata'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
@@ -100,6 +101,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <main id="main-content" className="flex-1">{children}</main>
             <Footer />
           </div>
+          <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
         </ThemeProvider>
       </body>
     </html>

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -30,11 +30,8 @@ const siteMetadata = {
     // content security policy in the `next.config.js` file.
     // supports Plausible, Simple Analytics, Umami, Posthog or Google Analytics.
     umamiAnalytics: {
-      // We use an env variable for this site to avoid other users cloning our analytics ID
-      umamiWebsiteId: process.env.NEXT_UMAMI_ID, // e.g. 123e4567-e89b-12d3-a456-426614174000
-      // You may also need to overwrite the script if you're storing data in the US - ex:
-      // src: 'https://us.umami.is/script.js'
-      // Remember to add 'us.umami.is' in `next.config.js` as a permitted domain for the CSP
+      umamiWebsiteId: '4146d4ac-e488-4608-9098-514aa8129294',
+      src: 'https://cloud.umami.is/script.js',
     },
     // plausibleAnalytics: {
     //   plausibleDataDomain: '', // e.g. tailwind-nextjs-starter-blog.vercel.app

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ import withBundleAnalyzer from '@next/bundle-analyzer'
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app cloud.umami.is;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
## Summary

- Loads the Umami Cloud tracker via pliny's typed Analytics component (reads siteMetadata.analytics)
- Website ID + cloud.umami.is script src set in siteMetadata.js
- CSP script-src updated to allow cloud.umami.is

## Consequences

- Pageviews + referrers start flowing to Umami Cloud on deploy. No cookies, no consent banner needed.

## Testing

- pnpm build passes; eslint clean
- Verified in a headless browser: script tag renders with the correct website ID, script.js loads, and the beacon fires to gateway.umami.is/api/send