### PR TITLE
content: use footnotes instead of References sections

### DIFF
--- a/data/blog/37000-lines-of-slop.mdx
+++ b/data/blog/37000-lines-of-slop.mdx
@@ -12,7 +12,7 @@ draft: false
 
 37,000 lines of code a day isn't a flex. It's a warning.
 
-Garry Tan claimed that number across five concurrent projects. Tech press reported it as proof of AI's power. [Scott Tolinski](https://www.youtube.com/watch?v=1r9n-HsBQsE) examined what actually happens when AI agents generate code at industrial scale without human review.
+Garry Tan claimed that number across five concurrent projects. Tech press reported it as proof of AI's power. Scott Tolinski[^1] examined what actually happens when AI agents generate code at industrial scale without human review.
 
 ## The Case Study
 
@@ -58,7 +58,7 @@ Without review, these issues accumulate. The codebase becomes digital landfill -
 
 ## Slowing Down
 
-[Mario Zechner](https://mariozechner.at/posts/2026-03-25-thoughts-on-slowing-the-fuck-down/), creator of the [Pi agent framework](https://pi.dev), argues the answer isn't abandoning AI. It's using it deliberately.
+Mario Zechner[^2], creator of the [Pi agent framework](https://pi.dev), argues the answer isn't abandoning AI. It's using it deliberately.
 
 His core argument: let the AI handle the boring, repetitive tasks that teach you nothing, then carefully evaluate what it produced.
 
@@ -69,7 +69,7 @@ Practical guidance from Zechner:
 
 ## Tooling for Hygiene
 
-Tolinski has been exploring [Fallow](https://docs.fallow.tools/) - a static analysis tool for TypeScript and JavaScript codebases that surfaces:
+Tolinski has been exploring Fallow[^3] - a static analysis tool for TypeScript and JavaScript codebases that surfaces:
 
 - Dead code
 - Duplicate lines
@@ -101,9 +101,6 @@ First approach produces slop. Second produces leverage.
 
 Next time you see someone bragging about AI line counts, ask how many lines were reviewed by a human who understood them. The answer tells you whether they're building software or generating slop.
 
-## References
-
-- [37,000 Lines of Slop - Syntax FM (Scott Tolinski)](https://www.youtube.com/watch?v=1r9n-HsBQsE)
-- [Thoughts on slowing the fuck down - Mario Zechner](https://mariozechner.at/posts/2026-03-25-thoughts-on-slowing-the-fuck-down/)
-- [Fallow - Codebase analyser for TypeScript/JavaScript](https://docs.fallow.tools/)
-- [Garry Tan's GStack - GitHub](https://github.com/garrytan/gstack/)
+[^1]: [37,000 Lines of Slop - Syntax FM (Scott Tolinski)](https://www.youtube.com/watch?v=1r9n-HsBQsE)
+[^2]: [Thoughts on slowing the fuck down - Mario Zechner](https://mariozechner.at/posts/2026-03-25-thoughts-on-slowing-the-fuck-down/)
+[^3]: [Fallow - Codebase analyser for TypeScript/JavaScript](https://docs.fallow.tools/)

--- a/data/blog/big-tech-engineers-need-big-egos.mdx
+++ b/data/blog/big-tech-engineers-need-big-egos.mdx
@@ -12,7 +12,7 @@ draft: false
 
 You need ego to work in big tech. Not the loud kind. The quiet kind that says "I can figure this out" even when the evidence says you can't.
 
-[Sean Goedecke](https://www.seangoedecke.com/big-tech-needs-big-egos/) argues this is not arrogance in the bully sense. It's a durable self-belief that survives constant confusion, incomplete knowledge, technical disagreement, and organisational friction. The kind that lets you act despite ignorance instead of freezing in it.
+Sean Goedecke[^1] argues this is not arrogance in the bully sense. It's a durable self-belief that survives constant confusion, incomplete knowledge, technical disagreement, and organisational friction. The kind that lets you act despite ignorance instead of freezing in it.
 
 ## Why Ego Matters in Engineering
 
@@ -79,14 +79,12 @@ This helps explain why strong big-tech staff engineers are rare. The switching i
 
 - **Big codebases need stabilising ego.** You'll be wrong and confused. Belief that you can still find the answer is the useful kind.
 - **Big tech rewards commitment.** Take positions, tolerate friction, interrupt bad reasoning.
-- **Org humility is the counterweight.** Strategy isn't your layer. Don't personalise executive reversals.
+- **Org humility is the counterweight.** Strategy isn't your layer. Don't personalise executive reversals. Matt Hogg's framing of ego, empathy and humility[^2] lands in a similar place.
 - **Effective staff engineers are chameleons.** High ego with peers, low ego with executives.
 
 ## What's Next
 
 Next time you feel hesitation in a technical debate, ask: is my silence helping the project, or just protecting my comfort? The answer usually tells you whether you need more ego in that room, not less.
 
-## References
-
-- [Sean Goedecke - Big tech engineers need big egos](https://www.seangoedecke.com/big-tech-needs-big-egos/)
-- [Matt Hogg - A unified theory of ego, empathy and humility at work](https://matthogg.fyi/a-unified-theory-of-ego-empathy-and-humility-at-work/)
+[^1]: [Sean Goedecke - Big tech engineers need big egos](https://www.seangoedecke.com/big-tech-needs-big-egos/)
+[^2]: [Matt Hogg - A unified theory of ego, empathy and humility at work](https://matthogg.fyi/a-unified-theory-of-ego-empathy-and-humility-at-work/)

--- a/data/blog/career-growth-stagnant-environment.mdx
+++ b/data/blog/career-growth-stagnant-environment.mdx
@@ -16,7 +16,7 @@ But when your ambition outpaces your environment, the friction gets exhausting u
 
 ## Build Your Own Career Pyramid
 
-[Steve McConnell's](https://en.wikipedia.org/wiki/Steve_McConnell) career pyramid idea: define what you're building toward, or your current environment becomes your ceiling.
+Steve McConnell's[^1] career pyramid idea: define what you're building toward, or your current environment becomes your ceiling.
 
 **Know what you want.** What skills? What impact? What's the long-term goal? A clear vision provides sustained motivation when the day-to-day feels like a treadmill.
 
@@ -82,6 +82,4 @@ Ask hiring managers: "Tell me about the last person on your team who grew into a
 
 Next time you feel your environment limiting you, ask: am I waiting for permission, or creating my own momentum? That difference determines whether you stagnate or accelerate.
 
-## References
-
-- [Steve McConnell](https://en.wikipedia.org/wiki/Steve_McConnell)
+[^1]: [Steve McConnell](https://en.wikipedia.org/wiki/Steve_McConnell) - author of *Code Complete* and the career pyramid framing used throughout this post.

--- a/skills/blog-writing/SKILL.md
+++ b/skills/blog-writing/SKILL.md
@@ -212,6 +212,7 @@ The site renders these automatically; write to take advantage of them:
 - **Mermaid**: ```mermaid blocks render in the site theme. Use `flowchart LR/TD`, short node labels, for loops and pipelines.
 - **Images**: files go in `public/images/blog/`; add an italic caption with author + license on the next line (styles automatically). Wikimedia Commons CC/PD sources preferred.
 - **Tables**: plain markdown tables, styling is automatic.
+- **Footnotes over References sections**: cite sources inline with `[^1]` at first mention, define them at the bottom (`[^1]: [Title](url) - note`). Do not add a `## References` list. Keep the body readable; the footnote holds the full link and context.
 - Full design rules live in `skills/site-conventions/SKILL.md`.
 
 ## Illustration Tooling


### PR DESCRIPTION
## Summary

- Converts the three posts that still had \`## References\` lists (37k Lines of Slop, Big Tech Egos, Career Growth) to inline \`[^n]\` footnotes at first mention
- Documents the convention in the blog-writing skill: footnotes over References sections

## Consequences

- None; footnote styling already exists in globals.css via remark-gfm

## Testing

- pnpm build passes; verified footnote refs and backrefs in exported HTML