### PR TITLE
feat: render giscus comments on blog posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ yarn-error.log*
 
 # Contentlayer
 .contentlayer
+
+# TypeScript incremental build cache
+*.tsbuildinfo

--- a/components/blog-post.tsx
+++ b/components/blog-post.tsx
@@ -5,8 +5,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
 import { MDXLayoutRenderer } from 'pliny/mdx-components.js'
+import { Comments } from 'pliny/comments'
 import { components } from '@/components/mdx-components'
 import HeroPattern from '@/components/hero-pattern'
+import siteMetadata from '@/data/siteMetadata'
 import { format, formatDistanceToNow, parseISO } from 'date-fns'
 import type { Blog, Authors } from 'contentlayer/generated'
 
@@ -91,6 +93,16 @@ export function BlogPost({ post }: BlogPostProps) {
           <MDXLayoutRenderer code={post.body.code} components={components} />
         </div>
       </article>
+
+      {siteMetadata.comments?.provider && (
+        <section
+          aria-label="Comments"
+          className="mt-12 border-t pt-10 md:mt-16 md:pt-12"
+        >
+          <h2 className="mono-label mb-6">comments</h2>
+          <Comments commentsConfig={siteMetadata.comments} />
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Renders pliny's `<Comments>` component at the foot of every blog post (`components/blog-post.tsx`), gated on `siteMetadata.comments?.provider`
- Adds `*.tsbuildinfo` to `.gitignore` so TypeScript incremental cache files don't leak into commits

## Context

Replaces #20, which was incorrectly targeted at the stale `main` branch and merged 465 unrelated files into `main` via squash. `main` has been force-reset back to its pre-bad-merge state. This PR targets `master` (the default and deployed branch) with only the two intended changes.

## Consequences

- None beyond the visible diff. The existing `giscusConfig` in `data/siteMetadata.js` and the `giscus.app` entries in the CSP (`next.config.ts`) already support this - no further config required.

## Testing

- `pnpm lint` - clean for `blog-post.tsx` and `.gitignore` (pre-existing errors elsewhere are unrelated)
- `tsc --noEmit` - only the pre-existing `baseUrl` deprecation warning in `tsconfig.json`
- Verified `node_modules/pliny/comments/{Giscus,index}.js` resolves correctly